### PR TITLE
OPSWAT Filescan Sandbox Integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ This library currently supports the following sandbox systems:
 * `FireEye AX Series`_
 * `Hatching Triage`_
 * `Joe Sandbox`_
-* `OPSWAT Sandbox`_
+* `OPSWAT Filescan Sandbox`_
 * `VMRay Analyzer`_
 * `WildFire Sandbox`_
 
@@ -242,20 +242,23 @@ Example::
 Currently, only the WildFire cloud sandbox is supported and not the WildFire appliance.
 
 
-OPSWAT Sandbox
-~~~~~~~~~~~~~~
+OPSWAT Filescan Sandbox
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Constructor signature::
 
-    OpswatAPI(apikey, profile, verify_ssl=True)
+    OPSWATSandboxAPI(api_key, url=None, verify_ssl=True)
 
 Example::
 
-    OpswatAPI(apikey, 'windows7')
+    OPSWATSandboxAPI('mykey')
 
-OPSWAT sandbox on MetaDefender Cloud. Please create an account on `OPSWAT portal`_ to receive a free MetaDefender Cloud apikey.
+OPSWAT Filescan Sandbox. You can use the Activation Key that you received 
+from your OPSWAT Sales Representative, and follow the instructions on the 
+`OPSWAT Licence Activation`_ page or you can create an API key on the 
+`OPSWAT Filescan Community Site`_ under API Key tab.
 
-More details in the `OPSWAT API documentation`_.
+More details in the `OPSWAT Filescan Sandbox API documentation`_.
 
 
 Hatching Triage
@@ -297,8 +300,9 @@ number of online analysis services.
 .. _AX Series product page: https://www.fireeye.com/products/malware-analysis.html
 .. _official Joe Sandbox library: https://github.com/joesecurity/joesandboxcloudapi
 .. _official Falcon library: https://github.com/PayloadSecurity/VxAPI
-.. _OPSWAT portal: https://go.opswat.com
-.. _OPSWAT API documentation: https://onlinehelp.opswat.com/mdcloud/10._Dynamic_analysis.html
+.. _OPSWAT Licence Activation: https://docs.opswat.com/filescan/installation/license-activation
+.. _OPSWAT Filescan Community Site: https://www.filescan.io/users/profile
+.. _OPSWAT Filescan Sandbox API documentation: https://docs.opswat.com/filescan/opswat-filescan
 .. _malsub: https://github.com/diogo-fernan/malsub
 .. _Triage public cloud: https://tria.ge/
 .. _Triage API documentation: https://tria.ge/docs/

--- a/sandboxapi/__init__.py
+++ b/sandboxapi/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     'fireeye',
     'joe',
     'triage',
+    'opswat',
     'vmray',
     'falcon',
     'wildfire',

--- a/sandboxapi/opswat.py
+++ b/sandboxapi/opswat.py
@@ -142,7 +142,7 @@ class OPSWATSandboxAPI(sandboxapi.SandboxAPI):
         """
         if report_format == "html":
             return "Report Unavailable"
-        
+
         filters = [
             "filter=general",
             "filter=finalVerdict",

--- a/sandboxapi/opswat.py
+++ b/sandboxapi/opswat.py
@@ -11,7 +11,7 @@ class OPSWATSandboxAPI(sandboxapi.SandboxAPI):
     def __init__(
         self, api_key, url="https://www.filescan.io", verify_ssl=True, **kwargs
     ):
-        """
+        """Initialize the interface to OPSWAT Filescan Sandbox API.
         :type   api_key:    str
         :param  api_key:    OPSWAT Filescan Sandbox API key
 
@@ -19,8 +19,6 @@ class OPSWATSandboxAPI(sandboxapi.SandboxAPI):
         :param  url         The url (including the port) of the OPSWAT Filescan Sandbox
                             instance defaults to https://www.filescan.io
         """
-
-        """Initialize the interface to OPSWAT Filescan Sandbox API."""
         sandboxapi.SandboxAPI.__init__(self, **kwargs)
         self.api_key = api_key
         self.api_url = url
@@ -142,7 +140,6 @@ class OPSWATSandboxAPI(sandboxapi.SandboxAPI):
         :return: Dictionary representing the JSON parsed data or raw, for other
                  formats / JSON parsing failure.
         """
-        
         if report_format == "html":
             return "Report Unavailable"
         
@@ -176,7 +173,7 @@ class OPSWATSandboxAPI(sandboxapi.SandboxAPI):
         """Pass in the report from self.report(), get back an int."""
         report_scores = [0]
         reports = report.get("reports", {})
-        for report_key, report_value in reports.items():
+        for report_value in reports.values():
             score = 0
             threat_level = report_value.get("finalVerdict", {}).get("threatLevel", 0)
             report_scores.append(max(0, threat_level) * 100)
@@ -205,6 +202,10 @@ if __name__ == "__main__":
         msg = "%s: <filescan_url> <api_key> <submit <file_path> | available | report <flow_id> | score <report> | analyze <file_path>"
         print(msg % sys.argv[0])
         sys.exit(1)
+
+    cmd = None
+    api_key = None
+    url = None
 
     if len(sys.argv) == 4:
         cmd = sys.argv.pop().lower()

--- a/tests/resources/opswat_submissions_result_benign.json
+++ b/tests/resources/opswat_submissions_result_benign.json
@@ -1,0 +1,5578 @@
+{
+    "flowId": "6514d18233582f234e05276a",
+    "allFinished": true,
+    "allFilesDownloadFinished": true,
+    "allAdditionalStepsDone": true,
+    "reportsAmount": 1,
+    "priority": "least",
+    "pollPause": 12,
+    "fileSize": 1294917,
+    "sourceArchive": {
+        "scan_task_id": "8ac9f737-4e98-4793-8ba6-d63cd7696f6a",
+        "name": "sample.zip",
+        "mimeType": "application/zip",
+        "sha256": "d4990c542c0d2e55656a08ae4946f9b533444142bf2a5557d3a7e738af284d9f",
+        "private": false,
+        "is_link_upload": false,
+        "sha1": "2b8db2731fc7ff0b7a99c7b2c7d46dc5d675a919",
+        "sha512": "dad76250e7a02abed37ed0b590b559136a051212aa1db20e4a7558ae4e6587ef1f9fbea5903c451a86140c479b4f810ed6eefdcff9dba7781cd16a3b6ea85488",
+        "md5": "a9aec4126aa6b0c5ff85bbf4ffb8b9a9",
+        "tags": [
+            {
+                "source": "MEDIA_TYPE",
+                "tag": {
+                    "name": "zip"
+                }
+            }
+        ],
+        "verdict": "benign"
+    },
+    "reports": {
+        "c57ac83f-6019-4947-9f1a-35c77aac2a96": {
+            "finalVerdict": {
+                "verdict": "BENIGN",
+                "threatLevel": -1,
+                "confidence": 1
+            },
+            "allTags": [
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "peexe",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "html",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "xml",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "greyware",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "lolbin",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "shell32",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "greyware",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "lolbin",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "overlay",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "packed",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "shell32",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "UNKNOWN",
+                            "threatLevel": 0,
+                            "confidence": 1
+                        }
+                    }
+                }
+            ],
+            "overallState": "success",
+            "taskReference": {
+                "name": "transform-file",
+                "additionalInfo": {
+                    "submitName": "pingometer1_5.bin",
+                    "submitTime": 1695864087816,
+                    "digests": {
+                        "SHA-256": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                    },
+                    "context": {
+                        "contextData": "eJwBAAT/+1BLAwQUAwEACADRfjtXryi4Rp3BEwBI+BQAEQAAAHBpbmdvbWV0ZXIxXzUuYmlu4O3kAV2RCdqHjJNffBB/JwbHnBQYcaqNpovhcEoguwfmUYGXimplCcjyNTIhubIT3VTJ4VYTK6yzWto7SH9W4VLMuN6ytQ0a75ukew/MDFtDolQfkHL/O5fdsdvVRSGlK1AiNcxnRrvP0LlwM+84EyVIgcUqTJI8KU1Wj5cqZMV5sd/jS/qcjSu7Kiig29q++oyhDS6I32W0tsIBrC2qu2h8ExTKGEOvmaLwk7ThUMu3upm4reG/ijx7KTBbkycBa/ES5ftyJV+lKCpmIc8mV/37B13+ppmgP1SYXv1rPEoNCe1u029O7lNA8KvHzLovIeCA/SmEClNzP+kUIAR+HAv8xVKU312HsaLoz3/G4UU4FIJuqYHZ9vVOiPNtOAkzsng3mooGQU8Zl/VOZ5P9eHbZuR/QCVj+pW5lVAudmTg+VIhMhx1qzvo0zpMyttTBhzf+4ZM1hoJM/k6aEHFfhDjZF/jIEvq7JHLExlC9RIG9J0SNxiMoXDcL7LHBNMKY5v3qnOWamvojfih0jmGE5iiMoesCuZsErGRkdYrryG0E/S8i0LOmpKrOGyzKeW37+9GVTKs/xhROjr/j5noAxC0CNL5Bgb5wxEV6vTEV66VG4ROoASS/K6idjbsVrEArWOsd0NU5pyA0JTBkjtLGG3DDYRR16KlBQ/7wr59uZhEHl6epX3k4Vu4K+MtEmjh4fgyhHwL1ne7VoeFibySUoxria3flvzu35zcFkGu4TFist/TwQ+327mNAqsT6QPSlFIAVM382nRi0avGjOtERa3rEesYsMrfhq1pbc1r+RkbxFffkeO3dNxiJuq3oPycrUoSTZDeUCHcrCP6WWHb59kJjsaj2cFYINP3zurd7n+XYJTQj4rATy8eq6QqAo8kot+snzvj6WSYnj6A104utxYoYnjYMF2W5mOTcRfou2Hr78gzdrh78AG0NlAz6FIYsX3ylwI8n9Sse9Zc/Y2Px6hE7aq/Y85VpJKr1Zl5p/AXbl9RC+8ysXqeC3OyvGo6JeFUi2KpKDh7YEfsgePNT+x56hxz6OMIB8iofPDBfMy3OIb8tbSmY8JE4CXXIZOBHOpLgBXPiXsSg8Z6en/hrGYOv4M35ecRzKt48+p9xrDyc63Y2mSXabMaMSwzF42BBa167nLKdbb8GFReCck2ibp0ACg4GowfHz0a+2GKnE8Hj/fdb+tcpb768Isn1GiPb0EouIjXPZd7SEXC10J3gK7ibjcVA9h4VzrlwIZejpEmetz9II2DZCnmU2rsV9YEbRInuOGAnPw1bS6fbWi9xylFSAPsY",
+                        "contextDataIsPartial": true,
+                        "contextOriginalSize": 1374280,
+                        "contextIdentifier": "d4990c542c0d2e55656a08ae4946f9b533444142bf2a5557d3a7e738af284d9f",
+                        "contextType": "PARENT_FILE",
+                        "metaData": {
+                            "additionalHashes": {
+                                "MD5": "a9aec4126aa6b0c5ff85bbf4ffb8b9a9",
+                                "SHA-1": "2b8db2731fc7ff0b7a99c7b2c7d46dc5d675a919",
+                                "SHA-512": "dad76250e7a02abed37ed0b590b559136a051212aa1db20e4a7558ae4e6587ef1f9fbea5903c451a86140c479b4f810ed6eefdcff9dba7781cd16a3b6ea85488"
+                            },
+                            "totalArchiveFiles": 1,
+                            "name": "sample.zip",
+                            "additionalInfo": "MEDIA_TYPE:zip"
+                        }
+                    }
+                },
+                "ID": "bc9b2fda-6223-49c7-a367-bcec38aaf3a4",
+                "state": "SUCCESS",
+                "resourceReference": {
+                    "type": "TRANSFORM_FILE",
+                    "name": "file",
+                    "ID": "d90d2e92-5b3b-4128-93d7-0ab5c01e5b23"
+                },
+                "opcount": 1,
+                "processTime": 25098
+            },
+            "subtaskReferences": [
+                {
+                    "name": "visualization",
+                    "additionalInfo": "6310dbe6-639b-4d62-b129-d34b2478f946",
+                    "ID": "aed65a42-c7ed-442e-8af4-b136a5d39637",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "VISUALIZATION",
+                        "name": "visualization",
+                        "ID": "6310dbe6-639b-4d62-b129-d34b2478f946"
+                    },
+                    "opcount": 1,
+                    "processTime": 320
+                },
+                {
+                    "name": "osint",
+                    "additionalInfo": "d90d2e92-5b3b-4128-93d7-0ab5c01e5b23",
+                    "ID": "56b5d5ec-c164-425a-a69f-31d0956cf387",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "91b76bd0-abe3-4961-b9c4-e18d29dbbd75"
+                    },
+                    "opcount": 4,
+                    "processTime": 1013
+                },
+                {
+                    "name": "domain-resolve",
+                    "additionalInfo": 3,
+                    "ID": "f2699e18-be73-44d7-9897-7fdc6f336627",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "DOMAIN_RESOLVE",
+                        "name": "domain-resolve",
+                        "ID": "d459645a-27c5-4791-8199-8fab1e61a64b"
+                    },
+                    "opcount": 2,
+                    "processTime": 1131
+                },
+                {
+                    "name": "file-download",
+                    "additionalInfo": 8,
+                    "ID": "2a8b9977-3992-4597-8975-bfdd7b572c45",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "FILE_DOWNLOAD",
+                        "name": "file-download",
+                        "ID": "9234a34f-65aa-44e3-bd82-87cd1ce337be"
+                    },
+                    "opcount": 8,
+                    "processTime": 7295
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "FILE_HASH_SHA256",
+                    "ID": "50e812b1-39d6-46b2-b4c2-d733601c6194",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "188b01f3-b0fb-4bb8-acec-8082b8fab76a"
+                    },
+                    "opcount": 52,
+                    "processTime": 4067
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "URL",
+                    "ID": "5320b667-974a-47e7-905b-9733b807d200",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "4c5c419c-d495-480a-8fa2-ccb409564703"
+                    },
+                    "opcount": 4,
+                    "processTime": 1051
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "DOMAIN",
+                    "ID": "ee25c617-2aa7-41d9-9f8c-e2019ed4b44a",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "ee64450e-be0b-4df2-8273-11a363f84537"
+                    },
+                    "opcount": 0,
+                    "processTime": 6
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "EMAIL",
+                    "ID": "2b447481-8b53-484f-926f-d8c837487200",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "d1faa0c7-d84d-4589-85a3-e14e05753482"
+                    },
+                    "opcount": 2,
+                    "processTime": 25
+                },
+                {
+                    "name": "osint-fuzzyhash",
+                    "additionalInfo": "d90d2e92-5b3b-4128-93d7-0ab5c01e5b23",
+                    "ID": "c0c18356-a80b-4409-8b94-4283d3f2b127",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "e2f65b0c-8e1b-419f-a398-9ac5b03e80e6"
+                    },
+                    "opcount": 2,
+                    "processTime": 1007
+                }
+            ],
+            "allSignalGroups": [
+                {
+                    "identifier": "SIGG017",
+                    "description": "Executable may be carrying a suspicious packed payload",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "signalReadable": "A non-installer executable is not digitally signed and contains high-entropy (packed) data likely to be executed",
+                            "additionalInfo": "",
+                            "originPath": "signalSummary.allTags",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "dataUUID": "d90d2e92-5b3b-4128-93d7-0ab5c01e5b23"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S007",
+                    "description": "Found a Windows desktop utility string artifact",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found string artifact \"where\"",
+                            "originPath": "file.strings.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"where\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H060",
+                    "description": "PE has icon",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.2,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"0a1aaeecc53ede5cdbaf1f5cbd0c83421a2d0902424b955cc2aea98c5d785ef6\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"fa0dfa9c55080ae3b2b836954fd2885f404844881c23d8a20fa4f6245c207e48\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"55d1e60e7e11924da2896e53051bd8966205a208a9a0aa06a4b6157b09bd0cce\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"0a1aaeecc53ede5cdbaf1f5cbd0c83421a2d0902424b955cc2aea98c5d785ef6\")",
+                            "originPath": "file.extractedFiles.extendedData.resources.resources",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"fa0dfa9c55080ae3b2b836954fd2885f404844881c23d8a20fa4f6245c207e48\")",
+                            "originPath": "file.extractedFiles.extendedData.resources.resources",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"55d1e60e7e11924da2896e53051bd8966205a208a9a0aa06a4b6157b09bd0cce\")",
+                            "originPath": "file.extractedFiles.extendedData.resources.resources",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda\")",
+                            "originPath": "file.extractedFiles.extendedData.resources.resources",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf\")",
+                            "originPath": "file.extractedFiles.extendedData.resources.resources",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H041",
+                    "description": "PE imports APIs often used by malware",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "greyware",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "greyware",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetFileType@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "greyware",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"GetFileType@KERNEL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "greyware",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H062",
+                    "description": "PE takes commandline arguments",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1059",
+                            "relatedTactic": {
+                                "ID": "TA0002",
+                                "name": "Execution"
+                            },
+                            "name": "Command and Scripting Interpreter"
+                        }
+                    ],
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.2,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetCommandLineA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H032",
+                    "description": "PE imports APIs used to access or modify the registry",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1012",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "Query Registry"
+                        }
+                    ],
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"RegOpenKeyExA@ADVAPI32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"RegQueryValueExA@ADVAPI32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"RegCloseKey@ADVAPI32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"RegOpenKeyExA@ADVAPI32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"RegQueryValueExA@ADVAPI32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"RegCloseKey@ADVAPI32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "PE005",
+                    "description": "PE contains an untrusted digital certificate",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7\" contains a \"self-signed\" digital signature from \"OU=\\\"NO LIABILITY ACCEPTED, (c)97 VeriSign, Inc.\\\", OU=VeriSign Time Stamping Service Root, OU=\\\"VeriSign, Inc.\\\", O=VeriSign Trust Network\" (Serial: 1389b4d18ae8a7c4bd35c79b8d88ca1fca535691)",
+                            "additionalInfo": "1389b4d18ae8a7c4bd35c79b8d88ca1fca535691",
+                            "originPath": "file.certInfos",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H000",
+                    "description": "Executable section has an unusual entropy",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "\".data\" has an unusual entropy \"0.884210288525\"",
+                            "originPath": "file.extractedFiles.extendedData.sections.entropy",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H036",
+                    "description": "PE imports APIs used to create temporary files",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetTempPathA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"CreateFileA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"GetTempPathA@KERNEL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"CreateFileA@KERNEL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H016",
+                    "description": "PE imports APIs used to hide other imports",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetProcAddress@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"GetProcAddress@KERNEL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"LoadLibraryA@KERNEL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H004",
+                    "description": "PE imports suspicious APIs",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.2,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"WriteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetFileAttributes@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetFileTime@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"DeleteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetTempFileName@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LockResource@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LoadResource@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"CreateProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RemoveDirectory@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"FindNextFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"WritePrivateProfileSection@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"WritePrivateProfileString@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"MoveFileEx@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetFileSize@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"MapViewOfFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"UnmapViewOfFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetDiskFreeSpace@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"FindFirstFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetFileType@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetEnvironmentStrings@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"TerminateProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetWindowText@user32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SystemParametersInfo@user32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SHBrowseForFolder@shell32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SHGetPathFromIDList@shell32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LZCopy@lz32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LZClose@lz32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"WriteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"SetFileAttributes@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"SetFileTime@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"DeleteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"GetTempFileName@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"LockResource@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"LoadResource@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"CreateProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"RemoveDirectory@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"FindNextFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"WritePrivateProfileSection@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"WritePrivateProfileString@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"MoveFileEx@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"GetFileSize@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"MapViewOfFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"UnmapViewOfFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"GetDiskFreeSpace@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"FindFirstFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"GetFileType@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"GetEnvironmentStrings@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"TerminateProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"GetWindowText@user32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"SystemParametersInfo@user32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"SHBrowseForFolder@shell32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"SHGetPathFromIDList@shell32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"LZCopy@lz32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Import \"LZClose@lz32.dll\" is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H007",
+                    "description": "PE imports suspicious modules",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Imported module \"lz32.dll\" (related to \"compression\" activity) is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.module",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Imported module \"lz32.dll\" (related to \"compression\" activity) is marked as suspicious",
+                            "originPath": "file.extractedFiles.extendedData.importsEx.module",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H028",
+                    "description": "PE imports APIs used to launch other processes",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"CreateProcessA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"ShellExecuteA@SHELL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"CreateProcessA@KERNEL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found API reference \"ShellExecuteA@SHELL32.dll\"",
+                            "originPath": "file.extractedFiles.extendedData.imports.imports",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "PE004",
+                    "description": "PE header references a certificate",
+                    "averageSignalStrength": 0,
+                    "peakSignalStrength": 0,
+                    "finalSignalStrength": 0,
+                    "verdict": {
+                        "verdict": "UNKNOWN",
+                        "threatLevel": 0,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7\" contains header field related to digital certificate.",
+                            "additionalInfo": "",
+                            "originPath": "file.extendedData",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "EF001",
+                    "description": "Contains an overlay",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "overlay",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Input file has a \"1244232\" byte overlay at offset \"130048\"",
+                            "additionalInfo": "7bef3c3bd1935fe9e0be1dc835acc7cb5e027d16351bc9c3583d3782d1bc25a4",
+                            "originPath": "file.extractedFiles",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "overlay",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "EF002",
+                    "description": "Contains an overlay with an unusually high entropy",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "overlay",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "LIKELY_MALICIOUS",
+                                    "threatLevel": 0.75,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "packed",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Input file has a \"1244232\" byte overlay at offset \"130048\" with an entropy of \"7.99913454056\"",
+                            "additionalInfo": "7bef3c3bd1935fe9e0be1dc835acc7cb5e027d16351bc9c3583d3782d1bc25a4",
+                            "originPath": "file.extractedFiles",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "overlay",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "LIKELY_MALICIOUS",
+                                            "threatLevel": 0.75,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "packed",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S051",
+                    "description": "Found a living off the land (LotL) string artifact",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1218.011",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Rundll32"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "lolbin",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "shell32",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "lolbin",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "shell32",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "UNKNOWN",
+                                    "threatLevel": 0,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found string artifact \"shell32.dll\" (Execute)",
+                            "originPath": "file.strings.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "lolbin",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "shell32",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "mitreTechnique": {
+                                "ID": "T1218.011",
+                                "relatedTactic": {
+                                    "ID": "TA0005",
+                                    "name": "Defense Evasion"
+                                },
+                                "name": "Rundll32"
+                            }
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"shell32.dll\" (Execute)",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "lolbin",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "shell32",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "UNKNOWN",
+                                            "threatLevel": 0,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "mitreTechnique": {
+                                "ID": "T1218.011",
+                                "relatedTactic": {
+                                    "ID": "TA0005",
+                                    "name": "Defense Evasion"
+                                },
+                                "name": "Rundll32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I001",
+                    "description": "OSINT source detected benign resource(s)",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "f33a89eb6f51f70b4862cba1662937cc376a4432906d5f4b0483e4b01dda52fa"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "8110d740b485bcb06ff406b17001714c3a146fe6517098c9dc90d812b83389fd"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "D001",
+                    "description": "Found a domain referencing a social media service",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"instagram.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"linkedin.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"twitter.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S007",
+                    "description": "Found a Windows desktop utility string artifact",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found string artifact \"where\"",
+                            "originPath": "file.strings.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found string artifact \"convert\"",
+                            "originPath": "file.strings.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "HTML000",
+                    "description": "Embedded script size is high in proportion to the whole file",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.2,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Script to the whole file ratio is: \"97.60%\", which is remarkably high",
+                            "originPath": "file.extendedData",
+                            "originType": "DOWNLOADED_FILE",
+                            "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                        }
+                    ]
+                }
+            ],
+            "resources": {
+                "188b01f3-b0fb-4bb8-acec-8082b8fab76a": {
+                    "results": [
+                        {
+                            "resource": "a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf",
+                            "origin": {
+                                "type": "INPUT_FILE",
+                                "identifier": "f33a89eb6f51f70b4862cba1662937cc376a4432906d5f4b0483e4b01dda52fa"
+                            },
+                            "type": "FILE_HASH_SHA256",
+                            "osintProvider": "OPSWAT_REPUTATION",
+                            "data": {
+                                "scan_result_history_length": 47,
+                                "sandbox": false,
+                                "file_id": "bzIzMDUyMjlFdFktTUlDTQ",
+                                "data_id": "YnpJek1EVXlNamxGZEZrdFRVbERUUTdNUEJ5SXM5OFM",
+                                "process_info": {
+                                    "progress_percentage": 100,
+                                    "profile": "multiscan_unarchive",
+                                    "result": "Allowed",
+                                    "blocked_reason": "",
+                                    "file_type_skipped_scan": false,
+                                    "post_processing": {
+                                        "actions_failed": "",
+                                        "actions_ran": "",
+                                        "converted_destination": "",
+                                        "converted_to": "",
+                                        "copy_move_destination": ""
+                                    },
+                                    "verdicts": [
+                                        "No Threat Detected"
+                                    ],
+                                    "blocked_reasons": []
+                                },
+                                "parent_data_id": "YnpJek1EVXlNamxGZEZrdFRVbERUUU5XWFdOWkJvWmY",
+                                "scan_results": {
+                                    "scan_details": {
+                                        "AegisLab": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T07:51:19.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "AhnLab": {
+                                            "scan_time": 1,
+                                            "def_time": "2023-05-23T00:00:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Antiy": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-23T03:01:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Avira": {
+                                            "scan_time": 2,
+                                            "def_time": "2023-05-22T17:24:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Bitdefender": {
+                                            "scan_time": 28,
+                                            "def_time": "2023-05-22T19:57:22.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "ClamAV": {
+                                            "scan_time": 100,
+                                            "def_time": "2023-05-22T07:23:18.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Comodo": {
+                                            "scan_time": 25,
+                                            "def_time": "2023-05-22T12:54:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "CrowdStrike Falcon ML": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T00:00:00.000Z",
+                                            "scan_result_i": 23,
+                                            "threat_found": ""
+                                        },
+                                        "Cyren": {
+                                            "scan_time": 24,
+                                            "def_time": "2023-05-22T19:27:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "ESET": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T17:48:20.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Emsisoft": {
+                                            "scan_time": 10,
+                                            "def_time": "2023-05-22T16:03:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Filseclab": {
+                                            "scan_time": 962,
+                                            "def_time": "2023-05-17T22:53:50.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Huorong": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T10:35:52.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "IKARUS": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T18:14:11.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "K7": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T16:08:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Kaspersky": {
+                                            "scan_time": 3,
+                                            "def_time": "2023-05-22T18:19:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "McAfee": {
+                                            "scan_time": 11,
+                                            "def_time": "2023-05-22T00:00:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "NANOAV": {
+                                            "scan_time": 1,
+                                            "def_time": "2023-05-22T16:26:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Quick Heal": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T17:17:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "RocketCyber": {
+                                            "scan_time": 2,
+                                            "def_time": "2023-05-22T00:00:00.000Z",
+                                            "scan_result_i": 23,
+                                            "threat_found": ""
+                                        },
+                                        "Scrutiny": {
+                                            "scan_time": 3270,
+                                            "def_time": "2023-05-22T00:00:00.000Z",
+                                            "scan_result_i": 23,
+                                            "threat_found": ""
+                                        },
+                                        "Sophos": {
+                                            "scan_time": 985,
+                                            "def_time": "2023-05-22T00:38:21.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "TACHYON": {
+                                            "scan_time": 27,
+                                            "def_time": "2023-05-22T00:00:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Trend Micro": {
+                                            "scan_time": 1651,
+                                            "def_time": "2023-05-21T20:22:07.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Trend Micro HouseCall": {
+                                            "scan_time": 2014,
+                                            "def_time": "2023-05-21T20:33:36.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "VirusBlokAda": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T15:55:57.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Webroot SMD": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T08:11:18.000Z",
+                                            "scan_result_i": 23,
+                                            "threat_found": ""
+                                        },
+                                        "Microsoft Defender": {
+                                            "scan_time": 0,
+                                            "def_time": "2023-05-22T13:15:10.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Xvirus Anti-Malware": {
+                                            "scan_time": 3,
+                                            "def_time": "2023-05-21T19:43:12.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Zillya!": {
+                                            "scan_time": 2,
+                                            "def_time": "2023-05-22T18:19:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Vir__IT eXplorer": {
+                                            "scan_time": 152,
+                                            "def_time": "2023-05-22T12:35:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        },
+                                        "Vir__IT ML": {
+                                            "scan_time": 403,
+                                            "def_time": "2023-05-22T12:35:00.000Z",
+                                            "scan_result_i": 0,
+                                            "threat_found": ""
+                                        }
+                                    },
+                                    "scan_all_result_i": 0,
+                                    "current_av_result_i": 0,
+                                    "start_time": "2023-05-22T21:16:09.378Z",
+                                    "total_time": 3981,
+                                    "total_avs": 32,
+                                    "total_detected_avs": 0,
+                                    "progress_percentage": 100,
+                                    "scan_all_result_a": "No Threat Detected",
+                                    "current_av_result_a": "No Threat Detected"
+                                },
+                                "file_info": {
+                                    "file_size": 20,
+                                    "upload_timestamp": "2023-05-22T21:16:03.491Z",
+                                    "md5": "42CF62B780813706E75FB9F2B2E8C258",
+                                    "sha1": "A022D5C1CFDD8AACE0089F3E72F2EEDD41BDA464",
+                                    "sha256": "A0C9D012E2BF6B2FE05C2D97CB5594D97CF2F539E97935C12ABD7A3562F4D9BF",
+                                    "file_type_category": "O",
+                                    "file_type_description": "data",
+                                    "file_type_extension": "dat",
+                                    "display_name": "<n/a>"
+                                },
+                                "share_file": 1,
+                                "private_processing": 0,
+                                "rest_version": "4",
+                                "additional_info": [
+                                    "vulnerability"
+                                ],
+                                "votes": {
+                                    "up": 0,
+                                    "down": 0
+                                },
+                                "stored": false
+                            },
+                            "verdict": "INFORMATIONAL",
+                            "tags": [],
+                            "lookupTime": 154,
+                            "isCachedResult": true
+                        },
+                        {
+                            "resource": "e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda",
+                            "origin": {
+                                "type": "INPUT_FILE",
+                                "identifier": "8110d740b485bcb06ff406b17001714c3a146fe6517098c9dc90d812b83389fd"
+                            },
+                            "type": "FILE_HASH_SHA256",
+                            "osintProvider": "OPSWAT_REPUTATION",
+                            "data": {
+                                "scan_result_history_length": 2,
+                                "sandbox": false,
+                                "file_id": "bzIwMDkyMnhzYmJHR18xWA",
+                                "data_id": "YnpJd01Ea3lNbmh6WW1KSFIxOHhXQXY4UE1tV1VSR0t1",
+                                "process_info": {
+                                    "post_processing": {
+                                        "copy_move_destination": "",
+                                        "converted_to": "",
+                                        "converted_destination": "",
+                                        "actions_ran": "",
+                                        "actions_failed": ""
+                                    },
+                                    "result": "Allowed",
+                                    "progress_percentage": 100,
+                                    "profile": "multiscan_unarchive",
+                                    "file_type_skipped_scan": false,
+                                    "blocked_reason": "",
+                                    "verdicts": [
+                                        "No Threat Detected"
+                                    ],
+                                    "blocked_reasons": []
+                                },
+                                "parent_data_id": "YnpJd01Ea3lNbmh6WW1KSFIxOHhXQW9lSFdjUy1fRQ",
+                                "scan_results": {
+                                    "scan_details": {
+                                        "AegisLab": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T05:22:00.000Z"
+                                        },
+                                        "Ahnlab": {
+                                            "threat_found": "",
+                                            "scan_time": 1,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T00:00:00.000Z"
+                                        },
+                                        "Antiy": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T03:47:00.000Z"
+                                        },
+                                        "Avira": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T00:00:00.000Z"
+                                        },
+                                        "BitDefender": {
+                                            "threat_found": "",
+                                            "scan_time": 82,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T01:45:00.000Z"
+                                        },
+                                        "ByteHero": {
+                                            "threat_found": "",
+                                            "scan_time": 2554,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-20T00:00:00.000Z"
+                                        },
+                                        "ClamAV": {
+                                            "threat_found": "",
+                                            "scan_time": 6604,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T13:52:00.000Z"
+                                        },
+                                        "Comodo": {
+                                            "threat_found": "",
+                                            "scan_time": 2784,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T19:05:45.000Z"
+                                        },
+                                        "CrowdStrike Falcon ML": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 23,
+                                            "def_time": "2020-09-22T00:00:00.000Z"
+                                        },
+                                        "Cyren": {
+                                            "threat_found": "",
+                                            "scan_time": 10,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T03:10:00.000Z"
+                                        },
+                                        "ESET": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T00:00:00.000Z"
+                                        },
+                                        "Emsisoft": {
+                                            "threat_found": "",
+                                            "scan_time": 21,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T14:24:00.000Z"
+                                        },
+                                        "F-prot": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T02:00:00.000Z"
+                                        },
+                                        "Filseclab": {
+                                            "threat_found": "",
+                                            "scan_time": 3670,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-20T22:50:00.000Z"
+                                        },
+                                        "Fortinet": {
+                                            "threat_found": "",
+                                            "scan_time": 811,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T00:00:00.000Z"
+                                        },
+                                        "Hauri": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T00:00:00.000Z"
+                                        },
+                                        "Huorong": {
+                                            "threat_found": "",
+                                            "scan_time": 230,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T09:32:00.000Z"
+                                        },
+                                        "Ikarus": {
+                                            "threat_found": "",
+                                            "scan_time": 1,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T18:14:18.000Z"
+                                        },
+                                        "Jiangmin": {
+                                            "threat_found": "",
+                                            "scan_time": 8637,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-19T19:22:00.000Z"
+                                        },
+                                        "K7": {
+                                            "threat_found": "",
+                                            "scan_time": 1,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T11:23:00.000Z"
+                                        },
+                                        "Kaspersky": {
+                                            "threat_found": "",
+                                            "scan_time": 26,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T01:27:00.000Z"
+                                        },
+                                        "McAfee": {
+                                            "threat_found": "",
+                                            "scan_time": 137,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-20T00:00:00.000Z"
+                                        },
+                                        "NANOAV": {
+                                            "threat_found": "",
+                                            "scan_time": 1,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T22:13:00.000Z"
+                                        },
+                                        "Preventon": {
+                                            "threat_found": "",
+                                            "scan_time": 11549,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T22:29:00.000Z"
+                                        },
+                                        "Quick Heal": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T06:09:00.000Z"
+                                        },
+                                        "RocketCyber": {
+                                            "threat_found": "",
+                                            "scan_time": 2,
+                                            "scan_result_i": 23,
+                                            "def_time": "2020-09-22T00:00:00.000Z"
+                                        },
+                                        "Sophos": {
+                                            "threat_found": "",
+                                            "scan_time": 917,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T02:58:00.000Z"
+                                        },
+                                        "SUPERAntiSpyware": {
+                                            "threat_found": "",
+                                            "scan_time": 9355,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-17T20:23:00.000Z"
+                                        },
+                                        "TACHYON": {
+                                            "threat_found": "",
+                                            "scan_time": 188,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-22T05:00:00.000Z"
+                                        },
+                                        "TrendMicro": {
+                                            "threat_found": "",
+                                            "scan_time": 7094,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-20T20:22:00.000Z"
+                                        },
+                                        "TrendMicro House Call": {
+                                            "threat_found": "",
+                                            "scan_time": 6499,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-20T20:37:00.000Z"
+                                        },
+                                        "VirusBlokAda": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T08:23:00.000Z"
+                                        },
+                                        "Webroot SMD": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 23,
+                                            "def_time": "2020-09-21T09:00:14.000Z"
+                                        },
+                                        "Windows Defender": {
+                                            "threat_found": "",
+                                            "scan_time": 308,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T23:53:26.000Z"
+                                        },
+                                        "Xvirus Personal Guard": {
+                                            "threat_found": "",
+                                            "scan_time": 46,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T03:35:00.000Z"
+                                        },
+                                        "Zillya!": {
+                                            "threat_found": "",
+                                            "scan_time": 2,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-19T13:57:00.000Z"
+                                        },
+                                        "Vir__IT eXplorer": {
+                                            "threat_found": "",
+                                            "scan_time": 1,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T11:40:00.000Z"
+                                        },
+                                        "Vir__IT ML": {
+                                            "threat_found": "",
+                                            "scan_time": 0,
+                                            "scan_result_i": 0,
+                                            "def_time": "2020-09-21T14:46:00.000Z"
+                                        }
+                                    },
+                                    "scan_all_result_i": 0,
+                                    "current_av_result_i": 0,
+                                    "start_time": "2020-09-22T05:56:06.949Z",
+                                    "total_time": 69903,
+                                    "total_avs": 38,
+                                    "total_detected_avs": 0,
+                                    "progress_percentage": 100,
+                                    "scan_all_result_a": "No Threat Detected",
+                                    "current_av_result_a": "No Threat Detected"
+                                },
+                                "file_info": {
+                                    "file_size": 34,
+                                    "upload_timestamp": "2020-09-22T05:56:05.431Z",
+                                    "md5": "29A1F473B6FC0B877CE30BE83212F25A",
+                                    "sha1": "A66309103E9F7FF118FD964F2CD5AE04BBD4A322",
+                                    "sha256": "E5D571D7F26FA57C7E00290D0FA8AEF8C1D519983E0AA5ECD75F5D4B41FA4CDA",
+                                    "file_type_category": "O",
+                                    "file_type_description": "data",
+                                    "file_type_extension": "dat",
+                                    "display_name": "DRPSuPacker\\drp\\.rsrc\\GROUP_ICON\\128"
+                                },
+                                "share_file": 0,
+                                "rest_version": "4",
+                                "additional_info": [],
+                                "votes": {
+                                    "up": 0,
+                                    "down": 0
+                                },
+                                "stored": false
+                            },
+                            "verdict": "INFORMATIONAL",
+                            "tags": [],
+                            "lookupTime": 253,
+                            "isCachedResult": true
+                        },
+                        {
+                            "resource": "11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344",
+                            "origin": {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            "type": "FILE_HASH_SHA256",
+                            "osintProvider": "OPSWAT_REPUTATION",
+                            "data": {
+                                "file_info": {
+                                    "sha256": "11BD13D42F1F62FDD4BB646455842B5B55B564A7D1C40D4BBB567FB7DB437344"
+                                },
+                                "scan_results": {
+                                    "scan_details": {
+                                        "Kaspersky": {
+                                            "scan_result_i": 0,
+                                            "threat_found": "",
+                                            "def_time": "2011-02-08T04:03:00"
+                                        }
+                                    },
+                                    "scan_all_result_i": 0,
+                                    "scan_all_result_a": "No threat detected",
+                                    "total_detected_avs": 0,
+                                    "total_avs": 1
+                                },
+                                "malware_type": []
+                            },
+                            "verdict": "INFORMATIONAL",
+                            "tags": [],
+                            "lookupTime": 268
+                        },
+                        {
+                            "resource": "f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d",
+                            "origin": {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            "type": "FILE_HASH_SHA256",
+                            "osintProvider": "OPSWAT_REPUTATION",
+                            "data": {
+                                "file_info": {
+                                    "sha256": "F929A23B7992AEC06C2D4BC29E4E595E5C1CEC1215C0CC00488EF649D266279D"
+                                },
+                                "scan_results": {
+                                    "scan_details": {
+                                        "Avira": {
+                                            "scan_result_i": 0,
+                                            "threat_found": "",
+                                            "def_time": "2023-06-08T12:03:35.455Z"
+                                        }
+                                    },
+                                    "scan_all_result_i": 0,
+                                    "scan_all_result_a": "No threat detected",
+                                    "total_detected_avs": 0,
+                                    "total_avs": 1
+                                },
+                                "malware_type": []
+                            },
+                            "verdict": "INFORMATIONAL",
+                            "tags": [],
+                            "lookupTime": 262
+                        }
+                    ],
+                    "relatedTaskType": "OSINT_EXTENDED",
+                    "origin": {
+                        "type": "INPUT_FILE",
+                        "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                    },
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "188b01f3-b0fb-4bb8-acec-8082b8fab76a"
+                    },
+                    "mediaType": {
+                        "string": "application/octet-stream",
+                        "slash": 11,
+                        "semicolon": 24,
+                        "parameters": {}
+                    },
+                    "signalGroupsByID": {
+                        "I001": {
+                            "identifier": "I001",
+                            "description": "OSINT source detected benign resource(s)",
+                            "averageSignalStrength": 0.1,
+                            "peakSignalStrength": 0.1,
+                            "finalSignalStrength": 0.1,
+                            "verdict": {
+                                "verdict": "INFORMATIONAL",
+                                "threatLevel": 0.1,
+                                "confidence": 1
+                            },
+                            "allTags": [],
+                            "signals": [
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "f33a89eb6f51f70b4862cba1662937cc376a4432906d5f4b0483e4b01dda52fa"
+                                },
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "8110d740b485bcb06ff406b17001714c3a146fe6517098c9dc90d812b83389fd"
+                                },
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                                },
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                                }
+                            ]
+                        }
+                    },
+                    "signalGroups": [
+                        {
+                            "identifier": "I001",
+                            "description": "OSINT source detected benign resource(s)",
+                            "averageSignalStrength": 0.1,
+                            "peakSignalStrength": 0.1,
+                            "finalSignalStrength": 0.1,
+                            "verdict": {
+                                "verdict": "INFORMATIONAL",
+                                "threatLevel": 0.1,
+                                "confidence": 1
+                            },
+                            "allTags": [],
+                            "signals": [
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "f33a89eb6f51f70b4862cba1662937cc376a4432906d5f4b0483e4b01dda52fa"
+                                },
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "8110d740b485bcb06ff406b17001714c3a146fe6517098c9dc90d812b83389fd"
+                                },
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                                },
+                                {
+                                    "strength": 0.1,
+                                    "isStrictlyBasedOnInputData": false,
+                                    "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d\" as \"INFORMATIONAL\"",
+                                    "additionalInfo": "f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d",
+                                    "originPath": "osint.results.verdict",
+                                    "originType": "INPUT_FILE",
+                                    "originIdentifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                                }
+                            ]
+                        }
+                    ],
+                    "allTags": [],
+                    "originVerdicts": [
+                        {
+                            "identifier": "8110d740b485bcb06ff406b17001714c3a146fe6517098c9dc90d812b83389fd",
+                            "verdict": {
+                                "verdict": "INFORMATIONAL",
+                                "threatLevel": 0.1,
+                                "confidence": 1
+                            }
+                        },
+                        {
+                            "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                            "verdict": {
+                                "verdict": "INFORMATIONAL",
+                                "threatLevel": 0.1,
+                                "confidence": 1
+                            }
+                        },
+                        {
+                            "identifier": "f33a89eb6f51f70b4862cba1662937cc376a4432906d5f4b0483e4b01dda52fa",
+                            "verdict": {
+                                "verdict": "INFORMATIONAL",
+                                "threatLevel": 0.1,
+                                "confidence": 1
+                            }
+                        }
+                    ],
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "notifications": []
+                }
+            },
+            "iocs": {
+                "sha1": [
+                    {
+                        "data": "902a9485936d9b2c1bed6b747b2ca97119cfdb26",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "44fdf6020192914cfc94eb7760d16f1258519575",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ff11c246651fe9afa146f6622fe596be981f49ea",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ae7a0af8ba1e8d4d3531fec6e5a7e9616956957d",
+                        "origins": [
+                            {
+                                "type": "PE_UNPACKING",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "cd18c97ae994e236bc01570e3cdede45f6199102",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "93090678ff9deff6f209b896fbb05dfe12e3bfe2",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "2b8db2731fc7ff0b7a99c7b2c7d46dc5d675a919",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "705ba1ee45e1cf79fdaf41a33e8e93975b686297",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a022d5c1cfdd8aace0089f3e72f2eedd41bda464",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e9571ec226340800aab97a131d456cf876e5a1ae",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e90b1c7b09a298a238ddf2754ff9ceabbc9e28ec",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a66309103e9f7ff118fd964f2cd5ae04bbd4a322",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "5eb1bde42c1372a9fe67313316b9f3e4aca6b7b9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "47d815eb50ad5faec66d647449b3b8e3cab109e9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "c11928a25124cbf7d34a1edcbcf9c4a9f2464016",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "da3d5452660de0b2a0ae97d076bd3688d3494edf",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "3ef317d9a236fc5df74d492bc2cbca4f0343e7fc",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "6964af963a08ff554afb05c9ab8fae2e66e53695",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "dc774c41b0bc451a9bb2c680eaca0a28cc0c4904",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a962b2b3b3c06093c05c05ba0c6785b4847ea457",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "44835120d21db96bbccce3ca1c84680de0f60cc3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "fab6212e32934430f2b207bdcb7fc02a940a274e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "fed036c74fe423f2cca81ec5a69aa58f7f0d0453",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "24d8724ab4a303a4eea3790245f985950ab8950f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0208453db06207b18a77a4b3e4eeb8ec50a29120",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "70fd58e7c7be659a038e09e1bc800e78806f4073",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha256": [
+                    {
+                        "data": "69c6ad296384fe515d9587d9328b2e47e3a12d0c5d54607468ef3802898ea3c4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "fa0dfa9c55080ae3b2b836954fd2885f404844881c23d8a20fa4f6245c207e48",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0a1aaeecc53ede5cdbaf1f5cbd0c83421a2d0902424b955cc2aea98c5d785ef6",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "68a0db9341fac879faa81750ee349edb083d9d19e1df88f190c2f81bb6730de9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ccfc798618c7494bb2c2140eb28e1f472578def8e314ff8b1dfb59f9c9bab925",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "930c2fc4582877b1ae749a7f6875348c69d0455f8bd3d2d0a9c6e82f9524d0c9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "70e1d752dc3268aa93aa7166dbf3c09eed9758cf1614e85375d39a660447486e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0944189f0eed816c99c4781b374567f891a71bd37322eb5ddd589415e91e87fb",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b4344daca5ab07f837312b6e6a3df9c9e42713d9415a9828e3760dd6f29d32b3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ccdee7ec322dc4f6802d6d58b737ca5f32bd27e5d351ead3c0d7d93b8441a45a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "11bd13d42f1f62fdd4bb646455842b5b55b564a7d1c40d4bbb567fb7db437344",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "98a9b93ecf50ef3be8568126be5de227a76dff99852ab3f36908b31db059dad1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "79bcf084108ca762180ca100e4489e0e3e3821e7e8dbc067e3a5d84b38936fd9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e5d571d7f26fa57c7e00290d0fa8aef8c1d519983e0aa5ecd75f5d4b41fa4cda",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f28eadb3a8e22725fad15076bc31147f5d034295a4364a47504d4b48768226cf",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a0c9d012e2bf6b2fe05c2d97cb5594d97cf2f539e97935c12abd7a3562f4d9bf",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13",
+                        "origins": [
+                            {
+                                "type": "PE_UNPACKING",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "f929a23b7992aec06c2d4bc29e4e595e5c1cec1215c0cc00488ef649d266279d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7e842f29c490c85109c4bf48ea0397be08815253a47c0898ee00a3869307cb7b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7bef3c3bd1935fe9e0be1dc835acc7cb5e027d16351bc9c3583d3782d1bc25a4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "55d1e60e7e11924da2896e53051bd8966205a208a9a0aa06a4b6157b09bd0cce",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "5f6499cf069d0a1ecc7fc190d51628328363609ed758f836995b698ef36cf1e0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a6a7ccde005eab6c4465302fee48ff722573af7c0474fa964f1643b2d658630a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a79c88d9b18c019b0803c1ffdc79100737da8d8c49cebcbd9f84b6878e5c9e84",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d4990c542c0d2e55656a08ae4946f9b533444142bf2a5557d3a7e738af284d9f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "cab09855dabf71ef8dbff402f2f8cdda3b994288457691b7f5d441e9254dcc00",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "domain": [
+                    {
+                        "data": "kqzyfj.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "jdoqocy.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "path.revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "verisign.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "youtube.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "info.revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "Flexera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "pagead2.googlesyndication.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "twitter.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "enduser.id",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "linkedin.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "obesearmadillo.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "use.typekit.net",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "schema.org",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "revenera.de",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "store.revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "googletagmanager.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "js-agent.newrelic.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "instagram.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "awltovhc.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "bam.nr-data.net",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "flexera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ogp.me",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "drupal.org",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "lduhtrp.net",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "installshield.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e.params.cat",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "community.flexera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "w3.org",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "NREUM.info",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "ip": [
+                    {
+                        "data": "75.2.65.169",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "74.208.236.156",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha512": [
+                    {
+                        "data": "9cec6a5ff2ab3b1a9dd27771a78a9d8b3c13f844fd06439e4b4d9b691ed066ca3d8735246f79e7fe03f5c05c9c9c0f2bfd89542f2aa9776f1df2269bfe4e434c",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "76dc5c48066fe39ec5cdf9e23425b154cf62955222eaf20a8750feaa8c9fdf35fc83faa459d0de849daa87979f25659bfd95dee97ea171dab8aa64629175edfd",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "1f6b383d6dd4cc71d3bbb52cb4fc96c5ed5fb44b99555910630a46c4c58bc2891c2588c8c7258972f81f34e529abf2f6c69c5912d049aad4914af7744bbc9888",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "dad76250e7a02abed37ed0b590b559136a051212aa1db20e4a7558ae4e6587ef1f9fbea5903c451a86140c479b4f810ed6eefdcff9dba7781cd16a3b6ea85488",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "52f992cea604ac404a6bb4b668ca62b9006735ff27708c7bf2c7b09fd86b3514865d5de59ebaac9dfcd2ef198ee386411b5d5cd9f03181f3f325bf447b979147",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ddb3fb48cea4d7609c057c2e47a55980c0853b93c290a5394618af144b0c2003b85dc57ce2dcdbe63f1d4284bc10ce3f61a298ad83c65e889ddb3dd9efbb7407",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0f9f15eea818569916e99dd9cd55898d61e8f0dafd660ea21fa8f89a1613527cb2d025049d50975beba6087a13ee304a23998dd9c9812c29ce688174a4052121",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e5500a05c35364e5d5e803818fc9050164efc669d3bcd33f22eaf556fb84c733daab4c8a1b9f07663af8fc77e3afb711c43c87a8083a20d1bd0e57ed55b4d61a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "21785416613242c5054499b5283127186553a2b78e140351fed5a4d7c582338848cc1cda257a859de36e18f2a38c31409cf11962afaf7e2543b1d06b454f65a4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "1553bd60eb32ca18d4e33c945f41b323e7eb410d7ab18d620ef081291afe123172a496afe4f8e225b2e67d6006f49949f601b49697e5ad9dd75487ef169b883b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0802769db00f1b9f83d42e6133b74d02455b1994f0b0866b2133b21498e35a90d3c38ff822f891597102dbabad488431d7b348ea4e57921729f341fc5a54aaf2",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "00a99b5f6419692dbbf238b2f3b138fdd831bf854f3a26bf9f50d3ae10fc0548bf381cd8255a0026c9b69d9118891d81abf8309435392b93f14fb8d73d2685a3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d628d2343d2c5e000e3681c0ecc136d71be38e966fb2973acafb5a5197f036f5b8162690235226c0ba8c3fcadd5afa63da99a9bb49c5faab4600b25b9c2ad5b6",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d40b87a1aa5d176e00d756ec29466707a344e49ed8f3d3bc01e74edfef42627b7c2699f6b2e053d163d7e3859a4be58591129287e494dcfeb6f13e637bee2254",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "396933c261c1a1bebc662b93e4af016e97df52f63421a065809ff42d40b5412dfa99cf46e043797ac3cd4e96ea7a387ad6ee2b7c92f7345f7c88e89a1e42fc25",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "1639fc29db22cba1324e7ea533ae9e827a1e21e224ba89c85abd14b8b139832c4b3ac37cbcbbe6060192c7634143702259e43b483579b2b6848415ffa06f2798",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e6738e71d15df0ee34370dfd1094ff460472b09d7e7178dd56509924740aa1e21913224e26b3cacb43fde202538b9fe84701c4f20a3ac489a8f15abdb8f604d1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8504f15138010c915159172a0561b2744c25d30e5fb50cb04e8250d48e16cb8e94ec934c831ae392c9ea3fe378047d3281198f22786d35e671871cdda8b18494",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "c9142cdfb7ea01ab6c59ffcb7db24779f8a89ec5a703fc5025e3e805d5d2d5fe7a22af592ca71194a1d81577b86e224fd2b8f16efbe7e4e0229f2e80e7a4b383",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ef1d03764f62f64021d1dfabc9ab3ddec22572f28c72fb437d89b74c0eb3790a772f301fa869a0b792426485a51e90d000cca3186e41f8f0c70ce094c0a7b616",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "defc495a1f45d748e4f0ddfe6f3c7573aec8dda71bb1b4c93cadf2eeb60b49bf5e1f3b763ca03abcecdb0738a53723fac7691740f2d8236bc2e3ddc91ecad3a1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "12a4739217a3691d42dedde4a8608f95fd238e68db883d4c7a960a3e62efa00ff6cc6c91dbab77c3c468d4fe1cb296b72f7c501822ea69d75ed535bac05dfc1a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "07dc048d64a030a72169db8b504e187a1c250b2a20d10b101f26c0976a0c4e9c7cece413a463133dff66d2ac6183b72ea0e4f0ba213f8b8c1fa44316aa87453a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "c2d32f5048b1e84e85f4a07a26301a1c6f60fa4f486e5c8703703cff8cb485d75df937fbecfd552b35e2de7d7594b2850a039fe20ed181403b04ac26d499746c",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7d28ebd45019c9ef2cb140a14a810de5bebc0bb817ef1da713ce081669130cc27a51e99c653d958cba64ef47f6647c1658b939ac1f2606e292ae409342af7809",
+                        "origins": [
+                            {
+                                "type": "PE_UNPACKING",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "c50bf28135f4e5a0d07ef5cf584e9d717d4d817c12acf5a2e04afc0d406f3edc443e0e603e3eb936bf7f364570b615ef154942ced8f8f504d786f43bc42833ae",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "email": [
+                    {
+                        "data": "CPS-requests@verisign.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "url": [
+                    {
+                        "data": "https://www.youtube.com/embed/046Qm_fEe2Y",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://schema.org/BreadcrumbList",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwhite-paper-industry-report%5D=white-paper-industry-report&amp;category%5Binstallation%5D=installation",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwebinar-event%5D=webinar-event&amp;category%5Bsoftware%20composition%20analysis%5D=software%20composition%20analysis",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/sites/default/files/2021-11/5-3fifty-fifty-hi-res_0010_istock-626999150-hires.jpeg",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/services-and-training/installation-design-and-development",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://pagead2.googlesyndication.com/pagead/show_ads.js",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwebinar-event%5D=webinar-event&amp;category%5Binstallation%5D=installation",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://use.typekit.net/fqx4jiy.css",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.installshield.com/pftw",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/industries/networking",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bdemo-trial%5D=demo-trial",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bcase-study%5D=case-study&amp;category%5Bsoftware%20monetization%5D=software%20monetization",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.verisign.com/repository/verisignlogo.gif0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://info.revenera.com/IS-EVNT-Unpacking-MSIX-2022",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.obesearmadillo.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.drupal.org",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/services-and-training/installation-training",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/diversity",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/business-solutions/open-source-vulnerability-management",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://info.revenera.com/IS-WBNR-TechTalk-Suite-Secrets?lead_source=Website%20Visitor&amp;id=Revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.verisign.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/services-and-training/implementation-services",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.googletagmanager.com/ns.html?id=GTM-P9Z3WSV",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products/usage-intelligence",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwebinar-event%5D=webinar-event&amp;category%5Bsoftware%20monetization%5D=software%20monetization",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/press-center",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions/monetizing-saas-applications",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bcase-study%5D=case-study",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.obesearmadillo.com/music.html",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/sites/default/files/datasheet-is.pdf",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://info.revenera.com/is-eval-installshield-premier?lead_source=Website%20Visitor&amp;id=Revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwebinar-event%5D=webinar-event",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?category%5Binstallation%5D=installation",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://path.revenera.com/c/everything-your-busi?x=Vuj5OO&amp;PFOVERLAY=TRUE",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.obesearmadillo.com/email.html",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/contact-us",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://store.revenera.com/shop/s/category/installshield/0ZG1M000000GmaTWAS",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installshield/installshield-requirements",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installanywhere",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installshield",
+                        "origins": [
+                            {
+                                "type": "DOWNLOADED_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "https://info.revenera.com/IS-WBNR-Developer-MSIX-eBook?lead_source=Website%20Visitor",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/services-and-training/training",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions/iot-manage-and-protect-devices",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products/software-licensing",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/industries/software-saas",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/products/sbom-insights",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions/flexible-monetization-models",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/audits-and-services/open-source-audits",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/services-and-training/installshield-microconsulting",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://verisign.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://path.revenera.com/getting-started-software-monetization?PFOVERLAY=TRUE",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions/monetize-iot",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.w3.org/2000/svg",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.verisign.com/repository/RPA",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.w3.org/1999/xhtml",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?category%5Bsoftware%20monetization%5D=software%20monetization",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products/software-delivery-and-updates",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/blog",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.awltovhc.com/image-2250652-54376",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products/entitlement-management",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://enduser.id",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products/renewals-and-customer-growth",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/sites/default/files/2021-11/5-3fifty-fifty-hi-res_0013_istock-623192890-hires_0.jpg",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.obesearmadillo.com/recording.html",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/industries/manufacturing-and-industrial-automation",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/services-and-training/revenue-recovery-services",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.flexera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://bam.nr-data.net",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.lduhtrp.net/image-2250652-10441635",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bvideo%5D=video&amp;category%5Bsoftware%20composition%20analysis%5D=software%20composition%20analysis",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions/better-products-with-software-usage-analytics",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/sites/default/files/datasheet_IS_CloudLicensServer.pdf",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/services-and-training/cloud-transformation",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?category%5Bsoftware%20composition%20analysis%5D=software%20composition%20analysis",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/industries",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://twitter.com/getrevenera",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/careers",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.kqzyfj.com/click-2250652-54376",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/products/compliance-intelligence",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://info.revenera.com/IS-EVAL-InstallShield-Professional?lead_source=Website%20Visitor&amp;id=Revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installshield/installshield-compare-versions",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/services-and-training",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installshield/installshield-tips-tricks",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installshield/cloud-license-server",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/glossary",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/business-solutions/open-source-license-compliance",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/sites/default/files/2022-08/917_IS_OpenGraph_BnrFINL1_01.png",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.verisign.com/repository/CPS",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://community.flexera.com/t5/Revenera-Community/ct-p/Revenera_Community",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.jdoqocy.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwhite-paper-industry-report%5D=white-paper-industry-report&amp;category%5Bsoftware%20composition%20analysis%5D=software%20composition%20analysis",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/audits-and-services/m-a-support",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwhite-paper-industry-report%5D=white-paper-industry-report",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bcase-study%5D=case-study&amp;category%5Binstallation%5D=installation",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/contact-us?C_Interest1=sales&amp;C_SolutionInterest=IS",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/partners",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://Flexera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/services-and-training",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.instagram.com/weareflexera",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/industries/medical-devices",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://schema.org/ListItem",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.de/install/products/installshield",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/install/products/installshield/installshield-compare-editions",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/products/flexnet-code-insight",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.linkedin.com/company/revenera",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://info.revenera.com/is-eval-installshield-professional?lead_source=Website%20Visitor&amp;id=Revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bvideo%5D=video",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/services-and-training/monetization-advisory-services",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/leadership",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.obesearmadillo.com/logic.html",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "080a5e3758a430def394ab12d3489d1044cd67775e92cc0bacc4ab0091eb1bc8"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/business-solutions/bill-of-materials",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-monetization/business-solutions/turn-software-piracy-into-revenue",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://ogp.me/ns",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources/podcasts",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/business-solutions",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/products",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/legal",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/legal/privacy-policy",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://js-agent.newrelic.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/about-us/environmental-social-governance",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://e.params.cat",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bwhite-paper-industry-report%5D=white-paper-industry-report&amp;category%5Bsoftware%20monetization%5D=software%20monetization",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/resources?type%5Bdatasheet%5D=datasheet",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.verisign.com/CPS0b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://community.flexera.com/t5/InstallShield/ct-p/InstallShield",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.youtube.com/GetRevenera",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/sites/default/files/2021-11/10-9fifty-fifty-solutions-hi-res_0004_istock-810529310-hires.jpg",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://info.revenera.com/IS-WP-MSIX-Windows-Installer?lead_source=Website%20Visitor&amp;id=Revenera.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://NREUM.info",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.revenera.com/software-composition-analysis/business-solutions/shift-left-automate-compliance-checks",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "8fd2ea50f96bddc896ef37d1c15a84bf1798e015f9e70c0a11fef0d5f58113e7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "registry_path": [
+                    {
+                        "data": "Software\\Microsoft\\Windows\\CurrentVersion",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "SOFTWARE\\Microsoft\\Windows\\CurrentVersion",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            },
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1d80f93292de4935e866d44b8366ddd98500209338964edadd1164318a6b3f13"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "md5": [
+                    {
+                        "data": "03b5ede2f69ab4c38248c23343fb0bc4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "51a889d3bec719183631726b8df3d2c7",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d6cbb03947ae3b6caee4f40a31a6efc3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f510cb89c20fee01ba052c6d44e8ead5",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "42cf62b780813706e75fb9f2b2e8c258",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "423993cf66da42d2b756bcc626aac542",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "2e7d1006ec3984179e5e99ce2329ab46",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f4d8081a150928db0756e919c4b6a907",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "aab9278fcdfa9354405e0acb1dbaa1a9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a9aec4126aa6b0c5ff85bbf4ffb8b9a9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8dd2374df1b5d36a8b3db3180059ea4f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7fbca12bf4a8557ded3c655c92230883",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d4390738ff142458cea229b978c42b0a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b500c994052c64fe569336cf1efccafe",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "06d8ecb1f74dbc4a646301f72ce5883d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7d12602ac2a4709d6bca0727525e6db4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "9b1fd2b7fe08d5e8afaea871011719df",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "878fed088d9a469820e44ff299827376",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "86323b8824ba4a53994dc60d55883c99",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a7a888b36e14f0628a4148a3393a919a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "75516b6fbb5af18f119e1d7f86136e2f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e434a9ad2c00a441d62b114f62b1c19a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "29a1f473b6fc0b877ce30be83212f25a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "03e5557d79d33dd4723e61265a3f8f3d",
+                        "origins": [
+                            {
+                                "type": "PE_UNPACKING",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "dfa2655bab51cec01e102903d2504538",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "366371343360dec3c4268042a88b8714",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ]
+            },
+            "file": {
+                "name": "pingometer1_5.bin",
+                "hash": "d70867d9597a6a6014637bca4fcccd93e595fb80d55bbf1ddeb82a5b5e97c3f7",
+                "type": "pe"
+            },
+            "filesDownloadFinished": true,
+            "additionalStepsRunning": [],
+            "additionalStepsDone": true,
+            "created_date": "09/28/2023, 01:22:09",
+            "defaultOptionsUsed": false,
+            "scanOptions": {
+                "rapid_mode": null,
+                "osint": true,
+                "extended_osint": true,
+                "extracted_files_osint": true,
+                "visualization": true,
+                "files_download": true,
+                "resolve_domains": true,
+                "input_file_yara": true,
+                "extracted_files_yara": true,
+                "whois": true,
+                "ips_meta": true,
+                "images_ocr": true
+            }
+        }
+    }
+}

--- a/tests/resources/opswat_submissions_result_likely_malicious.json
+++ b/tests/resources/opswat_submissions_result_likely_malicious.json
@@ -1,0 +1,2378 @@
+{
+    "flowId": "65315c2cafc17c7912f9006e",
+    "allFinished": true,
+    "allFilesDownloadFinished": true,
+    "allAdditionalStepsDone": true,
+    "reportsAmount": 1,
+    "priority": "least",
+    "pollPause": 12,
+    "fileSize": 12070912,
+    "fileReadProgressBytes": 12070912,
+    "reports": {
+        "421652fc-a024-4dbb-b852-3b84407937ba": {
+            "finalVerdict": {
+                "verdict": "LIKELY_MALICIOUS",
+                "threatLevel": 0.75,
+                "confidence": 1
+            },
+            "allTags": [
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "peexe",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "html",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "fingerprint",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "greyware",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "lolbin",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "shell32",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                }
+            ],
+            "overallState": "success",
+            "taskReference": {
+                "name": "transform-file",
+                "additionalInfo": {
+                    "submitName": "systeminformer-3.0.5553-setup.exe",
+                    "submitTime": 1697733679187,
+                    "digests": {
+                        "SHA-256": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                    }
+                },
+                "ID": "a25e8011-ab7c-4d93-94fa-b6ebfeb272e6",
+                "state": "SUCCESS",
+                "resourceReference": {
+                    "type": "TRANSFORM_FILE",
+                    "name": "file",
+                    "ID": "beb23f7c-c655-4290-b4aa-da6c1914dbfc"
+                },
+                "opcount": 1,
+                "processTime": 66898
+            },
+            "subtaskReferences": [
+                {
+                    "name": "visualization",
+                    "additionalInfo": "28d7efdf-08d7-448f-9d17-ba83d0bfd071",
+                    "ID": "97606424-8f9e-4f04-8f58-34533461cf12",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "VISUALIZATION",
+                        "name": "visualization",
+                        "ID": "28d7efdf-08d7-448f-9d17-ba83d0bfd071"
+                    },
+                    "opcount": 1,
+                    "processTime": 294
+                },
+                {
+                    "name": "osint",
+                    "additionalInfo": "beb23f7c-c655-4290-b4aa-da6c1914dbfc",
+                    "ID": "64e04459-6cf6-4d32-95ee-892489e6531c",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "eb7c53ed-bfa0-48e3-97e7-ca46687a6b48"
+                    },
+                    "opcount": 4,
+                    "processTime": 1007
+                },
+                {
+                    "name": "domain-resolve",
+                    "additionalInfo": 1,
+                    "ID": "9d2eaf8d-e165-4c83-95c4-304e3b4f2638",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "DOMAIN_RESOLVE",
+                        "name": "domain-resolve",
+                        "ID": "41d8fb26-f631-47a9-a982-2caa2791cdb0"
+                    },
+                    "opcount": 1,
+                    "processTime": 426
+                },
+                {
+                    "name": "file-download",
+                    "additionalInfo": 1,
+                    "ID": "9c14324d-084d-46da-aaa6-0a435e6b66aa",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "FILE_DOWNLOAD",
+                        "name": "file-download",
+                        "ID": "1dec5858-b897-47f0-b923-e4306ddf2963"
+                    },
+                    "opcount": 1,
+                    "processTime": 1754
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "FILE_HASH_SHA256",
+                    "ID": "586f9dd3-63dd-4366-9c58-38cb90050341",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "cc624907-425b-432e-8e3e-4278fe7d9023"
+                    },
+                    "opcount": 24,
+                    "processTime": 3109
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "URL",
+                    "ID": "f18d1b50-d1d7-4aae-9ae4-afcc7a4ef8a2",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "1979551d-35ef-4adc-adc1-e92fc446f619"
+                    },
+                    "opcount": 2,
+                    "processTime": 1007
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "DOMAIN",
+                    "ID": "25e57d3d-94d0-412c-8a58-e5573f585790",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "aab79d7b-84c2-4cc1-8f3e-9154f2540580"
+                    },
+                    "opcount": 0,
+                    "processTime": 5
+                },
+                {
+                    "name": "osint-fuzzyhash",
+                    "additionalInfo": "beb23f7c-c655-4290-b4aa-da6c1914dbfc",
+                    "ID": "2c2fe0c9-76bf-4f4e-97b9-dfb0aa1817e6",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "a30c02d0-c3f7-42ed-9baf-7ba5eb1f313c"
+                    },
+                    "opcount": 2,
+                    "processTime": 1006
+                }
+            ],
+            "allSignalGroups": [
+                {
+                    "identifier": "H060",
+                    "description": "PE has icon",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"f76d855baf101f0209ada77d5578f1262d4f66f3ed7d0840ea4424b67c384975\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"121e1ff6d1b35eaa61e6d0f749987bf5ad132f766cb3a854f7e67acba6c43905\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"6ded0c0f1078b5df222013d6338949f386a1cd74f765e9f89f936cd009368654\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"730b2f7d80a32012e260dde85efe6ba1fc69e76924e6f1f4dc07ac12af2eeed5\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"06e3f70e22e78a3d3455b69dff64a940e72c30f71b1d61dc8e3f1311c1bd8b55\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"7cafb9063223ed7d1ebbc3f2e42a81f4af5d6c7269d64920d353b4e29068ab5f\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"b179c7f33e2f9bdc69c79cb290c721b8130ebb9e64513785a3e226dd3e0e65ee\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"32f916805dfff7388c3643d49af8ec8b56f06a38e1c28660877a5d25747dccb1\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"d2950f6e1affbc5d2856b68ea54a36165271766c12b37d53d6c94da79fc386d4\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "R007",
+                    "description": "Found a registry reference often used for system fingerprinting",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1012",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "Query Registry"
+                        },
+                        {
+                            "ID": "T1082",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "System Information Discovery"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "fingerprint",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found registry artifact \"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SystemInformer\"",
+                            "originPath": "file.extractedRegistryPathways.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "fingerprint",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H041",
+                    "description": "PE imports APIs often used by malware",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "greyware",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetFileType@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "greyware",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H030",
+                    "description": "PE imports APIs used to manipulate/query other processes",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1518",
+                            "name": "Software Discovery"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtOpenProcess@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtOpenProcessToken@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H062",
+                    "description": "PE takes commandline arguments",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1059",
+                            "relatedTactic": {
+                                "ID": "TA0002",
+                                "name": "Execution"
+                            },
+                            "name": "Command and Scripting Interpreter"
+                        }
+                    ],
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetCommandLineW@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetCommandLineA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "R016",
+                    "description": "Found a system services related registry reference",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1007",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "System Service Discovery"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found registry artifact \"System\\CurrentControlSet\\Services\\\"",
+                            "originPath": "file.extractedRegistryPathways.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S028",
+                    "description": "Found a suspicious native API string artifact",
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntwritefile\" in string \"NtWriteFile\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntreadfile\" in string \"NtReadFile\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntqueryinformationprocess\" in string \"NtQueryInformationProcess\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntdelayexecution\" in string \"NtDelayExecution\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntopenprocess\" in string \"NtOpenProcessToken\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntquerysysteminformation\" in string \"NtQuerySystemInformation\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntquerysysteminformation\" in string \"NtQuerySystemInformationEx\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntopenprocess\" in string \"NtOpenProcess\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntsetinformationfile\" in string \"NtSetInformationFile\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntsetinformationthread\" in string \"NtSetInformationThread\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"rtlcreateuserthread\" in string \"RtlCreateUserThread\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found artifact \"ntcreatefile\" in string \"NtCreateFile\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H032",
+                    "description": "PE imports APIs used to access or modify the registry",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1012",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "Query Registry"
+                        }
+                    ],
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtCreateKey@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtCreateKeyedEvent@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtOpenKey@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtDeleteKey@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H011",
+                    "description": "PE imports APIs used for anti-debugging purposes",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtQuerySystemInformationEx@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtQuerySystemInformation@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NtQueryInformationProcess@ntdll.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H044",
+                    "description": "PE resources amount to more than 75% of the total file size",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "PE resources amount to 96.26% of the total file size",
+                            "originPath": "file.extendedData.stats.totalResourceAmountFromFileRatio",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H016",
+                    "description": "PE imports APIs used to hide other imports",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryExW@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryExA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetProcAddress@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H005",
+                    "description": "PE header timestamp is implausible",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "PE header timestamp (2100-06-16T11:03:12Z) is in the future",
+                            "originPath": "file.extendedData.dates.dateUnix",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H038",
+                    "description": "PE has an uncommon section name",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Entrypoint section \".didat\" is unusual",
+                            "originPath": "file.extendedData.sections.sectionName",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H004",
+                    "description": "PE imports suspicious APIs",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RtlCreateUserThread@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtCreateKey@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtCreateFile@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtQueryDirectoryFile@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtSetValueKey@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtSetEvent@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtSetInformationThread@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtSetInformationFile@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtOpenProcess@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtQuerySymbolicLinkObject@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtQuerySystemInformation@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtQueryVirtualMemory@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtOpenSymbolicLinkObject@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtOpenProcessToken@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LdrAccessResource@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RtlCreateSecurityDescriptor@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RtlCreateAcl@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RtlAddAccessAllowedAce@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtDelayExecution@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LdrFindResource_U@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtQueryInformationProcess@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RtlRandomEx@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RtlSetDaclSecurityDescriptor@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtQueryInformationFile@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtDeleteKey@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtTerminateProcess@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtReadFile@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NtWriteFile@ntdll.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetProcessHeap@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetEnvironmentVariable@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetEnvironmentStrings@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"FindNextFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetNativeSystemInfo@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"MoveFileEx@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"FindFirstFileEx@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetTimeZoneInformation@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"EnumSystemLocales@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetUserDefaultLCID@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetModuleHandleEx@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"WriteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetFileType@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetCurrentThreadId@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetCurrentProcessId@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"TerminateProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetUnhandledExceptionFilter@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"VirtualProtect@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RaiseException@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "Y001",
+                    "description": "Detected cryptographic algorithms",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1573",
+                            "name": "Encrypted Channel"
+                        }
+                    ],
+                    "averageSignalStrength": 0,
+                    "peakSignalStrength": 0,
+                    "finalSignalStrength": 0,
+                    "verdict": {
+                        "verdict": "UNKNOWN",
+                        "threatLevel": 0,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Detected constants related to \"MD5\"",
+                            "additionalInfo": "MD5",
+                            "originPath": "file.yaraMatches",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Detected constants related to \"SHA256\"",
+                            "additionalInfo": "SHA256",
+                            "originPath": "file.yaraMatches",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "R000",
+                    "description": "Found an autostart registry reference",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1547.001",
+                            "name": "Registry Run Keys / Startup Folder"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found registry artifact \"Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\taskmgr.exe\"",
+                            "originPath": "file.extractedRegistryPathways.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found registry artifact \"System\\CurrentControlSet\\Control\\NetworkProvider\\Order\"",
+                            "originPath": "file.extractedRegistryPathways.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found registry artifact \"System\\CurrentControlSet\\Services\\\"",
+                            "originPath": "file.extractedRegistryPathways.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "Y000",
+                    "description": "Matched a suspicious YARA rule",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Matched YARA rule \"BitcoinAddress\" with strength \"0.25\" (Contains a valid Bitcoin address)",
+                            "additionalInfo": "BitcoinAddress",
+                            "originPath": "file.extractedFiles.yaraMatches",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S051",
+                    "description": "Found a living off the land (LotL) string artifact",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1218.011",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Rundll32"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "lolbin",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "shell32",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"shell32.dll\" (Execute)",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "lolbin",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "shell32",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "mitreTechnique": {
+                                "ID": "T1218.011",
+                                "relatedTactic": {
+                                    "ID": "TA0005",
+                                    "name": "Defense Evasion"
+                                },
+                                "name": "Rundll32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S007",
+                    "description": "Found a Windows desktop utility string artifact",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found string artifact \"control\"",
+                            "originPath": "file.strings.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "D001",
+                    "description": "Found a domain referencing a social media service",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"reddit.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"twitter.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "D000",
+                    "description": "Found a domain referencing an instant messenger service",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"discord.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                        }
+                    ]
+                }
+            ],
+            "resources": {
+                "cc624907-425b-432e-8e3e-4278fe7d9023": {
+                    "results": [],
+                    "relatedTaskType": "OSINT_EXTENDED",
+                    "origin": {
+                        "type": "INPUT_FILE",
+                        "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                    },
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "cc624907-425b-432e-8e3e-4278fe7d9023"
+                    },
+                    "mediaType": {
+                        "string": "application/octet-stream",
+                        "slash": 11,
+                        "semicolon": 24,
+                        "parameters": {}
+                    },
+                    "signalGroupsByID": {},
+                    "signalGroups": [],
+                    "allTags": [],
+                    "originVerdicts": [],
+                    "verdict": {
+                        "verdict": "UNKNOWN",
+                        "threatLevel": 0,
+                        "confidence": 1
+                    },
+                    "notifications": []
+                }
+            },
+            "iocs": {
+                "sha1": [
+                    {
+                        "data": "2140f095997ecb5e2fa04eac2a03798aa91ca77c",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "037cbe3ee4c5031c7bbaf636c06fcd0ceca3163f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0fd905120f9f0d4a3bf25a5d38c5c5c1b002b575",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "70a4185df036794ccdf08dc4954a5377d69dfbc1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ca03c2465e151ef087c5283451d8226c51b4e73e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7a23b580b683db93f72057624e37aecebbad4d7b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "eff53825b4fc73371fc4ed72d3fd989792a9d999",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8640fe52c6865c26d3b693a37cc6a69a027a8b31",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "687c72f045dd1d36923aad3b2c8368cd7f5af146",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8ca7a8fcabb0f89b86c2c4d598ba9e7fbae9dd39",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "3c5dc98ae914ba035a0b450b03f7c08722330047",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "4b94dadea78c0c2fb93181742ee3b6701cd068c8",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha256": [
+                    {
+                        "data": "996fc6d8dced765db9c3b8667c6a0026f4f4e9927c655808509999bc9f6db8e9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "6ded0c0f1078b5df222013d6338949f386a1cd74f765e9f89f936cd009368654",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f76d855baf101f0209ada77d5578f1262d4f66f3ed7d0840ea4424b67c384975",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "730b2f7d80a32012e260dde85efe6ba1fc69e76924e6f1f4dc07ac12af2eeed5",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a56af09b5340fb9a631e34f40f3e67878fb2c843c65e0f928c149c51c5ad139d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "32f916805dfff7388c3643d49af8ec8b56f06a38e1c28660877a5d25747dccb1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b179c7f33e2f9bdc69c79cb290c721b8130ebb9e64513785a3e226dd3e0e65ee",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7cafb9063223ed7d1ebbc3f2e42a81f4af5d6c7269d64920d353b4e29068ab5f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d2950f6e1affbc5d2856b68ea54a36165271766c12b37d53d6c94da79fc386d4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "9aec4d0f387168db648f16ee0e8e6e65d75703ecde1cd6f75ab32b92ce3f3b55",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "06e3f70e22e78a3d3455b69dff64a940e72c30f71b1d61dc8e3f1311c1bd8b55",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "121e1ff6d1b35eaa61e6d0f749987bf5ad132f766cb3a854f7e67acba6c43905",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "ip": [
+                    {
+                        "data": "172.64.148.49",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "domain": [
+                    {
+                        "data": "systeminformer.sourceforge.io",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "github.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "windows-internals.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "twitter.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "discord.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "reddit.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "googletagmanager.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "cdnjs.cloudflare.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "sourceforge.net",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha512": [
+                    {
+                        "data": "79c46463b4e3a867bf227c02e31bb65a9a7b92660027398b310d19e87cc5309f4841f906ca92d4854bbe00f8b9b3ec8fa547fe6465dcefbd7aa50f70ec95a6ed",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "2f09f1074cf73da51ffcbb67ad0f06374c5c07cd3edad45257403b0361470b31f0ab34b8bf0559a717461ea42a857d82b434988a35d57c45d9799f5178666af8",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "bde04cba879d41636177bc740e338f3e13094f2a1f9ee15a88e95492161436e258465956624253b796cd4411bbdd861a144388c97d893fa169822058b0b1ad52",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b913afd6e140dbd6b5a4c02250f23c046a7c0ae59bd31d08655982bdfe91d7cb5007923d3189cc03bd2390f69b0578500b170a0b35361e8dd7c3a3426fd09731",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7869401945de9204de6534a501847b88855a2d2d520ecd1639c6d7ba40129f10ea69cad9a4d41b114838499035aa7b64c4d7b288e2c66da2a65f0a4a3903ca2c",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e0476a561576a9444b06a13337f345ef816f44acdd7c440adb8854f4ba8697f169e34f42ba050d089a1ffab939f09345ac0dbcdba9bd24070c0fa929d37f5b9c",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8da9d234d9e776ea3499be7be733cb7601c061e8a796d649ba28665c549a73fa3baf41354052704f9327e0236d616fcbd489cd58e011d1a1ab5723d915a4578b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "9e39dfcec4e0a5e458167588837bfa356d9bf879864feef90640114ed6b4d13ae7c3619e7f66599bec192152a0e6fc7f81931ad6883bc07dea346c7385d45135",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ba1512d2701d6a4c74fe5da651f7aa25f47864055c532f662737628f01593e5aa720a73a0501ae75455933dff48540b10115433a89f33d45870421f3b36609b9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f92f3918f23f31ec9e1bf459bfe7b952f01c1e918db02440d90ea51e1777709af438d008a524e09e7ae99225234c175b98872b70c699cbfc6c13cc5900251633",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a676c87bcab9ceb501090a4b45b50be9692c66aac559a33aaf4b4a04d346a9245f8cd76c4a0fe2f7b32787a1d3eab2b3ebdd3b15757a7c7f7d1084a2878df3a4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b9b204c184aa0e3f2d2ef76e496a1fb87693b9101354c540d0c53faa0e34e5eb1fade0ace31c0cd509d9fdf0d95e10070715410863e375c7008f17517cd70c34",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "url": [
+                    {
+                        "data": "https://twitter.com/SystemInformer",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.reddit.com/r/SystemInformer",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://windows-internals.com",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://sourceforge.net",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://discord.com/invite/k2MQd2DzC2",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://sourceforge.net/projects/systeminformer",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://github.com/winsiderss/systeminformer/issues/new",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://systeminformer.sourceforge.io/",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://www.googletagmanager.com/gtag/js?id=G-K180CJH0WK",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://sourceforge.net/sflogo.php?type=17&group_id=3524562",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://github.com/winsiderss/systeminformer",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "07f9bb751d6f0044e7b8d244d1f4ca3853b851a27ae76de4bfbb05518722de95"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "registry_path": [
+                    {
+                        "data": "System\\CurrentControlSet\\Control\\NetworkProvider\\Order",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "Software\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\taskmgr.exe",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "System\\CurrentControlSet\\Services\\",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": true
+                    },
+                    {
+                        "data": "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\SystemInformer",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": true
+                    }
+                ],
+                "md5": [
+                    {
+                        "data": "386460497d26e02cff34cb07ec23fce9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "74f09ee788a104a25844d80efb8731f3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "fff6f4aad64c0db2db24ec3d82061e33",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "c261a766c438189a9eb27647b3e03a17",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "582bba0fca976d644b77906186438624",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "afc224eac3afeb1ff06dbaf38ce5a98e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e1d9b2657d73c9615f768bd31ef34029",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ff538281ae9b1e9a0b27eeba23ee1a31",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "bae548ab480fa0fe4b77999a13affb67",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "26894c87fe4b48d66eedb1142aaec2d6",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "6db71fd254da17eba1a8800b06d97dec",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "047592239e8fc159740cf91535c04828",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ]
+            },
+            "file": {
+                "name": "systeminformer-3.0.5553-setup.exe",
+                "hash": "7b8117a93e65e797483799caa742829dc6d816c7118b363ab4fdb4b575351572",
+                "type": "pe"
+            },
+            "filesDownloadFinished": true,
+            "additionalStepsRunning": [],
+            "additionalStepsDone": true,
+            "created_date": "10/19/2023, 16:41:18",
+            "defaultOptionsUsed": true,
+            "scanOptions": {
+                "rapid_mode": false,
+                "osint": true,
+                "extended_osint": true,
+                "extracted_files_osint": true,
+                "visualization": true,
+                "files_download": true,
+                "resolve_domains": true,
+                "input_file_yara": true,
+                "extracted_files_yara": true,
+                "whois": true,
+                "ips_meta": true,
+                "images_ocr": true
+            },
+            "estimatedTime": "9",
+            "estimated_progress": 1.0
+        }
+    }
+}

--- a/tests/resources/opswat_submissions_result_malicious.json
+++ b/tests/resources/opswat_submissions_result_malicious.json
@@ -1,0 +1,1421 @@
+{
+    "flowId": "6531567f966b1cca70e9fce5",
+    "allFinished": true,
+    "allFilesDownloadFinished": false,
+    "allAdditionalStepsDone": false,
+    "reportsAmount": 1,
+    "priority": "max",
+    "pollPause": 5,
+    "fileSize": 13370880,
+    "fileReadProgressBytes": 13370880,
+    "reports": {
+        "f7977db1-6a99-46c3-8567-de1c88c93aa4": {
+            "finalVerdict": {
+                "verdict": "MALICIOUS",
+                "threatLevel": 1,
+                "confidence": 1
+            },
+            "allTags": [
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "peexe",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "html",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "OSINT_LOOKUP",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "tag": {
+                        "name": "emotet",
+                        "synonyms": [
+                            "geodo"
+                        ],
+                        "descriptions": [
+                            {
+                                "description": "While Emotet historically was a banking malware organized in a botnet, nowadays Emotet is mostly seen as infrastructure as a service for content delivery. For example, since mid 2018 it is used by Trickbot for installs, which may also lead to ransomware attacks using Ryuk, a combination observed several times against high-profile targets.\r\nIt is always stealing information from victims but what the criminal gang behind it did, was to open up another business channel by selling their infrastructure delivering additional malicious software. From malware analysts it has been classified into epochs depending on command and control, payloads, and delivery solutions which change over time.\r\nEmotet had been taken down by authorities in January 2021, though it appears to have sprung back to life in November 2021.",
+                                "cluster": {
+                                    "type": "malpedia",
+                                    "authors": [
+                                        "Davide Arcuri",
+                                        "Alexandre Dulaunoy",
+                                        "Steffen Enders",
+                                        "Andrea Garavaglia",
+                                        "Andras Iklody",
+                                        "Daniel Plohmann",
+                                        "Christophe Vandeplas"
+                                    ]
+                                }
+                            }
+                        ],
+                        "verdict": {
+                            "verdict": "LIKELY_MALICIOUS",
+                            "threatLevel": 0.75,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "YARA_RULE",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "pup",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "packed",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "installer",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.25,
+                            "confidence": 1
+                        }
+                    }
+                }
+            ],
+            "overallState": "success",
+            "taskReference": {
+                "name": "transform-file",
+                "additionalInfo": {
+                    "submitName": "bad_file.exe",
+                    "submitTime": 1697732225977,
+                    "digests": {
+                        "SHA-256": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                    }
+                },
+                "ID": "71bc4e97-1768-4fff-bb0b-01e74a753d06",
+                "state": "SUCCESS",
+                "resourceReference": {
+                    "type": "TRANSFORM_FILE",
+                    "name": "file",
+                    "ID": "fea87ff0-c606-42eb-9429-4704574ed797"
+                },
+                "opcount": 1,
+                "processTime": 11035
+            },
+            "subtaskReferences": [
+                {
+                    "name": "visualization",
+                    "additionalInfo": "64b0c8a4-6058-4ba9-9d8b-876e0f7ac9fa",
+                    "ID": "07783248-137d-4cb6-a079-b0a6e7006845",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "VISUALIZATION",
+                        "name": "visualization",
+                        "ID": "64b0c8a4-6058-4ba9-9d8b-876e0f7ac9fa"
+                    },
+                    "opcount": 1,
+                    "processTime": 305
+                },
+                {
+                    "name": "osint",
+                    "additionalInfo": "fea87ff0-c606-42eb-9429-4704574ed797",
+                    "ID": "c2aaf769-9b14-48d4-8516-b67b5bff26f8",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "e85b9142-5983-4a8a-82c0-125a87d6b436"
+                    },
+                    "opcount": 4,
+                    "processTime": 1015
+                },
+                {
+                    "name": "domain-resolve",
+                    "additionalInfo": 1,
+                    "ID": "128e1b65-9909-40f0-8a0c-41f8c42ca11b",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "DOMAIN_RESOLVE",
+                        "name": "domain-resolve",
+                        "ID": "e9e8e019-4717-466b-afd2-e49ed363a684"
+                    },
+                    "opcount": 1,
+                    "processTime": 752
+                },
+                {
+                    "name": "file-download",
+                    "additionalInfo": 2,
+                    "ID": "4ae14441-4b4a-4666-864f-29ee07cc29e5",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "FILE_DOWNLOAD",
+                        "name": "file-download",
+                        "ID": "259f6636-7e10-4cb3-9f89-592369c01788"
+                    },
+                    "opcount": 2,
+                    "processTime": 5655
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "FILE_HASH_SHA256",
+                    "ID": "be4c98f2-3bd3-401f-8a04-9c44d039f021",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "d4cd5114-f261-48c1-95e7-b50b679576e1"
+                    },
+                    "opcount": 12,
+                    "processTime": 2019
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "URL",
+                    "ID": "6a64c06f-17ea-4ddf-8147-581d328a5556",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "216aabd6-003b-42bb-b852-79a8551c93f2"
+                    },
+                    "opcount": 4,
+                    "processTime": 1011
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "DOMAIN",
+                    "ID": "f73a6e81-4b86-4723-af13-60c8d9300186",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "941717de-22de-464d-90b8-3de583a03aeb"
+                    },
+                    "opcount": 0,
+                    "processTime": 7
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "EMAIL",
+                    "ID": "93b0c704-2acc-43bd-b5dd-475828872e3d",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "c95ff990-3b3f-4249-8a83-f55407840fd5"
+                    },
+                    "opcount": 2,
+                    "processTime": 1007
+                },
+                {
+                    "name": "osint-fuzzyhash",
+                    "additionalInfo": "fea87ff0-c606-42eb-9429-4704574ed797",
+                    "ID": "1638f9ab-53ee-4d2d-a755-3dbf288b3317",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "4440be5b-7e89-4f25-a798-2d07e0f387df"
+                    },
+                    "opcount": 2,
+                    "processTime": 1006
+                }
+            ],
+            "allSignalGroups": [
+                {
+                    "identifier": "BIN001",
+                    "description": "The executable is using a known installer framework",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "installer",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "INFORMATIONAL",
+                                    "threatLevel": 0.25,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The analysis found the signature of a known installer framework (\"Installer: Tarma InstallMate(9.0)[-]\")",
+                            "originPath": "file.dieInfo",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "installer",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "INFORMATIONAL",
+                                            "threatLevel": 0.25,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H060",
+                    "description": "PE has icon",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"ca8fc96218d0a7e691dd7b95da05a27246439822d09b829af240523b28fd5bb3\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"2bffe07ec828bac7464ce2fe9ac531135758bd2f3a826a4ab3d54514e1a7f37f\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"91df84124d31708df229fad93c421b7fc6f02060f571f028d33d3ed3f6cc0db0\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"d1e1a7d27e0fc5855a5fc12f5a47f67edee075f769133b855d864b153a981e5a\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H062",
+                    "description": "PE takes commandline arguments",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1059",
+                            "relatedTactic": {
+                                "ID": "TA0002",
+                                "name": "Execution"
+                            },
+                            "name": "Command and Scripting Interpreter"
+                        }
+                    ],
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetCommandLineW@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I000",
+                    "description": "OSINT source detected malicious resource",
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc\" as \"LIKELY_MALICIOUS\"",
+                            "additionalInfo": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "originPath": "file.inputSampleOSINT.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H043",
+                    "description": "PE has a known suspicious section name",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Section \".tsustub\" is suspicious (probably \"TSULoader\")",
+                            "originPath": "file.extendedData.sections.name",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Section \".tsuarch\" is suspicious (probably \"TSULoader\")",
+                            "originPath": "file.extendedData.sections.name",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H001",
+                    "description": "PE section size is empty",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Section \".data\" is empty",
+                            "originPath": "file.extendedData.sections.sizeOfRawData",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H011",
+                    "description": "PE imports APIs used for anti-debugging purposes",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"OutputDebugStringA@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H000",
+                    "description": "Executable section has an unusual entropy",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "packed",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "\".tsustub\" has an unusual entropy \"7.99748325348\"",
+                            "originPath": "file.extendedData.sections.entropy",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "packed",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "\".tsuarch\" has an unusual entropy \"7.9999871254\"",
+                            "originPath": "file.extendedData.sections.entropy",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "packed",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H036",
+                    "description": "PE imports APIs used to create temporary files",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"CreateFileW@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetTempPathW@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H016",
+                    "description": "PE imports APIs used to hide other imports",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetProcAddress@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryW@KERNEL32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H038",
+                    "description": "PE has an uncommon section name",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Entrypoint section \".tsustub\" is unusual",
+                            "originPath": "file.extendedData.sections.sectionName",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Entrypoint section \".tsuarch\" is unusual",
+                            "originPath": "file.extendedData.sections.sectionName",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H004",
+                    "description": "PE imports suspicious APIs",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"OutputDebugString@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"UnmapViewOfFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"MapViewOfFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetFileSize@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"DeleteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetFileAttributes@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetCurrentThreadId@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetCurrentProcessId@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetProcessHeap@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"WriteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetFileTime@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "Y002",
+                    "description": "Matched a malicious YARA rule",
+                    "averageSignalStrength": 1,
+                    "peakSignalStrength": 1,
+                    "finalSignalStrength": 1,
+                    "verdict": {
+                        "verdict": "MALICIOUS",
+                        "threatLevel": 1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Matched YARA rule \"PUP_InstallRex_AntiFWb\" with strength \"0.75\" (Malware InstallRex / AntiFW)",
+                            "additionalInfo": "PUP_InstallRex_AntiFWb",
+                            "originPath": "file.yaraMatches",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "SIGG016",
+                    "description": "Executable is a digitally not signed installer",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "signalReadable": "Found an installer which is not digitally signed",
+                            "additionalInfo": "",
+                            "originPath": "signalSummary.allTags",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "dataUUID": "fea87ff0-c606-42eb-9429-4704574ed797"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I000",
+                    "description": "OSINT source detected malicious resource",
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc\" as \"LIKELY_MALICIOUS\"",
+                            "additionalInfo": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S007",
+                    "description": "Found a Windows desktop utility string artifact",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found string artifact \"help\"",
+                            "originPath": "file.strings.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "d096388a950b7215c86890ac3fbac62ff84db8c628a4fbf47dc03bf9b4d78ff2"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "D001",
+                    "description": "Found a domain referencing a social media service",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"facebook.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "d096388a950b7215c86890ac3fbac62ff84db8c628a4fbf47dc03bf9b4d78ff2"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain \"twitter.com\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "d096388a950b7215c86890ac3fbac62ff84db8c628a4fbf47dc03bf9b4d78ff2"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "D006",
+                    "description": "Found an unusual long domain part",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "Found domain part \"has-custom-content-position\" in \"has-custom-content-position.is\"",
+                            "originPath": "file.extractedDomains.references",
+                            "originType": "EXTRACTED_FILE",
+                            "originIdentifier": "d096388a950b7215c86890ac3fbac62ff84db8c628a4fbf47dc03bf9b4d78ff2"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I001",
+                    "description": "OSINT source detected benign resource(s)",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"ca8fc96218d0a7e691dd7b95da05a27246439822d09b829af240523b28fd5bb3\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "ca8fc96218d0a7e691dd7b95da05a27246439822d09b829af240523b28fd5bb3",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"d1e1a7d27e0fc5855a5fc12f5a47f67edee075f769133b855d864b153a981e5a\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "d1e1a7d27e0fc5855a5fc12f5a47f67edee075f769133b855d864b153a981e5a",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                        }
+                    ]
+                }
+            ],
+            "resources": {
+                "c95ff990-3b3f-4249-8a83-f55407840fd5": {
+                    "results": [],
+                    "relatedTaskType": "OSINT_EXTENDED",
+                    "origin": {
+                        "type": "INPUT_FILE",
+                        "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                    },
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "c95ff990-3b3f-4249-8a83-f55407840fd5"
+                    },
+                    "mediaType": {
+                        "string": "application/octet-stream",
+                        "slash": 11,
+                        "semicolon": 24,
+                        "parameters": {}
+                    },
+                    "signalGroupsByID": {},
+                    "signalGroups": [],
+                    "allTags": [],
+                    "originVerdicts": [],
+                    "verdict": {
+                        "verdict": "UNKNOWN",
+                        "threatLevel": 0,
+                        "confidence": 1
+                    },
+                    "notifications": []
+                }
+            },
+            "iocs": {
+                "sha1": [
+                    {
+                        "data": "1ddcdefd05be844fd865b15b1588fd7fbec9aa74",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b849a2b9901473810b5d74e6703be78c3a7e64e3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "3f9366c8f1a24eb83bdf4c0ba4c80a970a2b90bc",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f6f373c1c445fadfe8958d565cfa9ec9b24140ab",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e1cb5ee6aa2351da09955cfdd0f756b14fb0eb1a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "5cf9385fa3a8947ea28567893aed9557fdb874dc",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha256": [
+                    {
+                        "data": "2bffe07ec828bac7464ce2fe9ac531135758bd2f3a826a4ab3d54514e1a7f37f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "91df84124d31708df229fad93c421b7fc6f02060f571f028d33d3ed3f6cc0db0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ca8fc96218d0a7e691dd7b95da05a27246439822d09b829af240523b28fd5bb3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d1e1a7d27e0fc5855a5fc12f5a47f67edee075f769133b855d864b153a981e5a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "efb1f8561b8b28326bbec0c12f7e4d0c47d56e155d5a7d3f4e8282280a24a9be",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "38cd7b61b24fa1124f13365d74e45f05ac8f1cf99119a3efaaf861e8d935e695",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "ip": [
+                    {
+                        "data": "209.182.199.110",
+                        "origins": [
+                            {
+                                "type": "EXTERNAL_PARSER",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "domain": [
+                    {
+                        "data": "FedRetireSoftware.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            },
+                            {
+                                "type": "EXTERNAL_PARSER",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha512": [
+                    {
+                        "data": "a6e0eca813f5ad7fabfac8f85de76023ce337bdd5e502090a3a495d4af78644b944afccb74e70fc5142ad7b5406aa05170dc4fcce72a724227aaf3c0ecf55e93",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a07da0e625df1a8af7bbab1c2961a135aecfc0d6629c83f7766151fa72a26dfcc4a652eada53b0c7e66c4e78cb83cf1481477636d47e6a51e49895493f84193f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "cd6bb61df6bee35b264235c5bafb5200ef6fa52a0624667b883226133bae16238c1109e668cb6350ba22df6123207c34efbb68ea0a44859022bc836dad630ac5",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8ce46109dd556b464a8a699aa71351e0dfb3b1d13572636d87686e27a006b808016e2dbf095dd7a48489a03994909ed889cd1a583c3a68de799c41b3e303e805",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "60bc847291ac08d46a16473387c2fd29694fbf5ef04e5072a2398ae8240677c9d251b46f6b3ed33b97ab3dec67969dfeab860a51f21d7914801f35c10634aa1e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "682739bb0877e7de479096ba3505c0a387e85ca74e49cae0d37b14ab84aa5d6bdf179af69d6bde961e8fde43caa7c34fdc2c80950466441badc18880ab96715a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "uuid": [
+                    {
+                        "data": "1E453EA8-BB42-419D-8067-D2477A36B761",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "D449BC32-6D28-4AF0-BB00-AB3391EF0F9A",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "email": [
+                    {
+                        "data": "ActivationDepartment@FedRetireSoftware.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "url": [
+                    {
+                        "data": "http://www.FedRetireSoftware.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            },
+                            {
+                                "type": "EXTERNAL_PARSER",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://FedRetireSoftware.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            },
+                            {
+                                "type": "EXTERNAL_PARSER",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "md5": [
+                    {
+                        "data": "d691b46d83322997a7a692858dc82f32",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b9a036cce166cbf677a9c237e916f05d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "90ed3aac2a942e3067e6471b32860e77",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "55d84fb3a4ae16307380358dbdfa6fda",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "3105f8c4fb192d2b45b6d06902c54b32",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "290e99c8e500bd3ef4cabe3f970fa01e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ]
+            },
+            "file": {
+                "name": "bad_file.exe",
+                "hash": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                "type": "pe"
+            },
+            "filesDownloadFinished": false,
+            "additionalStepsRunning": [
+                "similarity_search"
+            ],
+            "additionalStepsDone": false,
+            "created_date": "10/19/2023, 16:17:05",
+            "defaultOptionsUsed": false,
+            "scanOptions": {
+                "rapid_mode": null,
+                "osint": true,
+                "extended_osint": true,
+                "extracted_files_osint": true,
+                "visualization": true,
+                "files_download": true,
+                "resolve_domains": true,
+                "input_file_yara": true,
+                "extracted_files_yara": true,
+                "whois": true,
+                "ips_meta": true,
+                "images_ocr": true
+            },
+            "estimatedTime": "9",
+            "estimated_progress": 1.0,
+            "allOsintTags": [
+                {
+                    "source": "OSINT_LOOKUP",
+                    "sourceIdentifier": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                    "tag": {
+                        "name": "emotet",
+                        "synonyms": [
+                            "geodo"
+                        ],
+                        "descriptions": [
+                            {
+                                "description": "While Emotet historically was a banking malware organized in a botnet, nowadays Emotet is mostly seen as infrastructure as a service for content delivery. For example, since mid 2018 it is used by Trickbot for installs, which may also lead to ransomware attacks using Ryuk, a combination observed several times against high-profile targets.\r\nIt is always stealing information from victims but what the criminal gang behind it did, was to open up another business channel by selling their infrastructure delivering additional malicious software. From malware analysts it has been classified into epochs depending on command and control, payloads, and delivery solutions which change over time.\r\nEmotet had been taken down by authorities in January 2021, though it appears to have sprung back to life in November 2021.",
+                                "cluster": {
+                                    "type": "malpedia",
+                                    "authors": [
+                                        "Davide Arcuri",
+                                        "Alexandre Dulaunoy",
+                                        "Steffen Enders",
+                                        "Andrea Garavaglia",
+                                        "Andras Iklody",
+                                        "Daniel Plohmann",
+                                        "Christophe Vandeplas"
+                                    ]
+                                }
+                            }
+                        ],
+                        "verdict": {
+                            "verdict": "LIKELY_MALICIOUS",
+                            "threatLevel": 0.75,
+                            "confidence": 1
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/resources/opswat_submissions_result_not_finished.json
+++ b/tests/resources/opswat_submissions_result_not_finished.json
@@ -1,0 +1,70 @@
+{
+    "flowId": "65316f10ba877ae559118c99",
+    "allFinished": false,
+    "allFilesDownloadFinished": false,
+    "allAdditionalStepsDone": false,
+    "reportsAmount": 1,
+    "priority": "max",
+    "pollPause": 5,
+    "fileSize": 13370880,
+    "fileReadProgressBytes": 13370880,
+    "reports": {
+        "761590d3-9fec-4ab9-846f-12db39b156b2": {
+            "finalVerdict": {
+                "verdict": "UNKNOWN",
+                "threatLevel": 0,
+                "confidence": 1
+            },
+            "allTags": [],
+            "overallState": "in_progress",
+            "taskReference": {
+                "name": "transform-file",
+                "additionalInfo": {
+                    "submitName": "bad_file.exe",
+                    "submitTime": 1697738514610,
+                    "digests": {
+                        "SHA-256": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc"
+                    }
+                },
+                "ID": "84e354e5-4d3c-4790-b6be-6b75c9fa9160",
+                "state": "IN_PROGRESS",
+                "opcount": 0,
+                "processTime": 0
+            },
+            "subtaskReferences": [],
+            "allSignalGroups": [],
+            "iocs": {},
+            "filter_errors": [
+                "Resource not found: ['osint', 'file']"
+            ],
+            "file": {
+                "name": "bad_file.exe",
+                "hash": "834d1dbfab8330ea5f1844f6e905ed0ac19d1033ee9a9f1122ad2051c56783dc",
+                "type": null
+            },
+            "filesDownloadFinished": false,
+            "additionalStepsRunning": [
+                "similarity_search"
+            ],
+            "additionalStepsDone": false,
+            "created_date": "10/19/2023, 18:01:53",
+            "defaultOptionsUsed": false,
+            "scanOptions": {
+                "rapid_mode": null,
+                "osint": true,
+                "extended_osint": true,
+                "extracted_files_osint": true,
+                "visualization": true,
+                "files_download": true,
+                "resolve_domains": true,
+                "input_file_yara": true,
+                "extracted_files_yara": true,
+                "whois": true,
+                "ips_meta": true,
+                "images_ocr": true
+            },
+            "estimatedTime": "8",
+            "estimated_progress": 0.40424999594688416
+        }
+    }
+}

--- a/tests/resources/opswat_submissions_result_suspicious.json
+++ b/tests/resources/opswat_submissions_result_suspicious.json
@@ -1,0 +1,3069 @@
+{
+    "flowId": "65315865368548c1702f2f29",
+    "allFinished": true,
+    "allFilesDownloadFinished": true,
+    "allAdditionalStepsDone": true,
+    "reportsAmount": 1,
+    "priority": "max",
+    "pollPause": 5,
+    "fileSize": 53610896,
+    "fileReadProgressBytes": 53610896,
+    "reports": {
+        "d3312ff7-aa7d-4a75-b8ba-a21dbc3a05e1": {
+            "finalVerdict": {
+                "verdict": "SUSPICIOUS",
+                "threatLevel": 0.5,
+                "confidence": 1
+            },
+            "allTags": [
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "peexe",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "html",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "MEDIA_TYPE",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": true,
+                    "tag": {
+                        "name": "xml",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.1,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "packed",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "LIKELY_MALICIOUS",
+                            "threatLevel": 0.75,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "overlay",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "setupapi",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "shell32",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "SUSPICIOUS",
+                            "threatLevel": 0.5,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "control",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.25,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "installer",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.25,
+                            "confidence": 1
+                        }
+                    }
+                },
+                {
+                    "source": "SIGNAL",
+                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                    "isRootTag": false,
+                    "tag": {
+                        "name": "lolbin",
+                        "synonyms": [],
+                        "descriptions": [],
+                        "verdict": {
+                            "verdict": "INFORMATIONAL",
+                            "threatLevel": 0.25,
+                            "confidence": 1
+                        }
+                    }
+                }
+            ],
+            "overallState": "success",
+            "taskReference": {
+                "name": "transform-file",
+                "additionalInfo": {
+                    "submitName": "assinador-serpro-4-2-0.exe",
+                    "submitTime": 1697732715243,
+                    "digests": {
+                        "SHA-256": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                    }
+                },
+                "ID": "0c188503-8d09-4436-bebe-94724420a9f7",
+                "state": "SUCCESS",
+                "resourceReference": {
+                    "type": "TRANSFORM_FILE",
+                    "name": "file",
+                    "ID": "a174480a-b1ec-4c3d-aed2-7f15b206c692"
+                },
+                "opcount": 1,
+                "processTime": 36245
+            },
+            "subtaskReferences": [
+                {
+                    "name": "visualization",
+                    "additionalInfo": "1010fb26-e2b1-47a4-96f2-9a248ed7861e",
+                    "ID": "b49a8e83-dd52-4445-b4ac-b1c3c8e77d43",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "VISUALIZATION",
+                        "name": "visualization",
+                        "ID": "1010fb26-e2b1-47a4-96f2-9a248ed7861e"
+                    },
+                    "opcount": 1,
+                    "processTime": 315
+                },
+                {
+                    "name": "osint",
+                    "additionalInfo": "a174480a-b1ec-4c3d-aed2-7f15b206c692",
+                    "ID": "346905ea-3ad9-4cde-a787-8276fec39a19",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "8e1a4862-5338-4310-abd5-6940125d1e08"
+                    },
+                    "opcount": 4,
+                    "processTime": 2009
+                },
+                {
+                    "name": "domain-resolve",
+                    "additionalInfo": 2,
+                    "ID": "f1aaa67d-f2cd-4fbb-a049-9b22115fe667",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "DOMAIN_RESOLVE",
+                        "name": "domain-resolve",
+                        "ID": "6e0d30b0-6297-47d5-a7f6-183cc7185335"
+                    },
+                    "opcount": 1,
+                    "processTime": 435
+                },
+                {
+                    "name": "file-download",
+                    "additionalInfo": 2,
+                    "ID": "2f7f87df-1fd1-4dab-b0cb-95e70ae20dc0",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "FILE_DOWNLOAD",
+                        "name": "file-download",
+                        "ID": "434d0549-04de-46e3-979b-bee8b5a102dc"
+                    },
+                    "opcount": 2,
+                    "processTime": 1371
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "FILE_HASH_SHA256",
+                    "ID": "18a96c92-aeda-453f-8de1-c4f5c06fbdc8",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "7d836969-21ba-4389-938e-baa048df0cb7"
+                    },
+                    "opcount": 46,
+                    "processTime": 3042
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "URL",
+                    "ID": "de1096dd-3880-4e27-862b-28929f319d7e",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "8131ecac-6500-4d13-9717-45a5df5036e5"
+                    },
+                    "opcount": 2,
+                    "processTime": 8
+                },
+                {
+                    "name": "osint-ex",
+                    "additionalInfo": "DOMAIN",
+                    "ID": "ecb4d89e-b4da-47a4-b258-876989d0bf2f",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "a320c10e-3db8-470a-9f09-1dcbe60cda84"
+                    },
+                    "opcount": 0,
+                    "processTime": 6
+                },
+                {
+                    "name": "osint-fuzzyhash",
+                    "additionalInfo": "a174480a-b1ec-4c3d-aed2-7f15b206c692",
+                    "ID": "87e54f48-f000-40d5-896a-b7b757c0aae8",
+                    "state": "SUCCESS",
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "8b0bfc9e-8456-41a6-b565-1f5f70f2a232"
+                    },
+                    "opcount": 2,
+                    "processTime": 1007
+                }
+            ],
+            "allSignalGroups": [
+                {
+                    "identifier": "H060",
+                    "description": "PE has icon",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"05febfad978958780fbcd54073fa28228f5375cf4e2d5df5310f3cd8e47e491f\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"30e3536a32c2509357a5472a0eff9335cb5b5607fde8d7ca82bd7a03f9a60ebc\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"63bc73ffa28e0af5077c1bb882c913cdcd2765a34288451c15b8fa832477cc43\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"e091f8e6206b0fba3798d99b465e8c33082ebed634fa71886e1a9f002e99730f\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_ICON\" (SHA256: \"30058e7862f12edbefb181bc36b6443828b9fba9d2f5bb6bfd4a3927d579e46b\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found a resource with \"RT_GROUP_ICON\" (SHA256: \"b3804a4ce8e8f4b7b07a26f688b4a122e22857398c9979cc869a215c50d2b70e\")",
+                            "originPath": "file.extendedData.resources.resources",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H062",
+                    "description": "PE takes commandline arguments",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1059",
+                            "relatedTactic": {
+                                "ID": "TA0002",
+                                "name": "Execution"
+                            },
+                            "name": "Command and Scripting Interpreter"
+                        }
+                    ],
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetCommandLineW@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H021",
+                    "description": "PE imports APIs used for code injection",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1055",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Process Injection"
+                        }
+                    ],
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"CreateThread@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"VirtualAlloc@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"OpenProcessToken@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H043",
+                    "description": "PE has a known suspicious section name",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Section \".edata\" is suspicious (probably \"Developed with  Easy Programming Language (EPL)\")",
+                            "originPath": "file.extendedData.sections.name",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H001",
+                    "description": "PE section size is empty",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Section \".bss\" is empty",
+                            "originPath": "file.extendedData.sections.sizeOfRawData",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Section \".tls\" is empty",
+                            "originPath": "file.extendedData.sections.sizeOfRawData",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H023",
+                    "description": "PE imports APIs used to query user information on remote machines",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1033",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "System Owner/User Discovery"
+                        }
+                    ],
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"NetWkstaGetInfo@netapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H025",
+                    "description": "PE imports APIs commonly used by packers",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"VirtualProtect@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"VirtualAlloc@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H002",
+                    "description": "PE has uncommon entrypoint section name",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Entrypoint section .itext is unusual",
+                            "originPath": "file.extendedData.entrypointName",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H027",
+                    "description": "PE imports APIs used to set privilege levels",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1033",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "System Owner/User Discovery"
+                        },
+                        {
+                            "ID": "T1134",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Access Token Manipulation"
+                        }
+                    ],
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"AdjustTokenPrivileges@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"OpenProcessToken@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H004",
+                    "description": "PE imports suspicious APIs",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetExitCodeProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"VirtualProtect@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"CreateProcess@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RaiseException@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SwitchToThread@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetCurrentThread@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LockResource@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetCurrentThreadId@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LoadResource@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SuspendThread@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetFileSize@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetThreadPriority@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"VerSetConditionMask@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetDiskFreeSpace@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"FindFirstFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"DeleteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"GetEnvironmentVariable@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"WriteFile@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"EnumCalendarInfo@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"RemoveDirectory@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"SetThreadLocale@kernel32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"ExitWindowsEx@user32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"NetWkstaGetInfo@netapi32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"ConvertStringSecurityDescriptorToSecurityDescriptor@advapi32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Import \"LookupPrivilegeValue@advapi32.dll\" is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H007",
+                    "description": "PE imports suspicious modules",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Imported module \"netapi32.dll\" (related to \"network\" activity) is marked as suspicious",
+                            "originPath": "file.extendedData.importsEx.module",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H028",
+                    "description": "PE imports APIs used to launch other processes",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"CreateProcessW@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "PE004",
+                    "description": "PE header references a certificate",
+                    "averageSignalStrength": 0,
+                    "peakSignalStrength": 0,
+                    "finalSignalStrength": 0,
+                    "verdict": {
+                        "verdict": "UNKNOWN",
+                        "threatLevel": 0,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" contains header field related to digital certificate.",
+                            "additionalInfo": "",
+                            "originPath": "file.extendedData",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "PE000",
+                    "description": "PE contains a valid certificate",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" contains a valid digital signature from \"CN=SERVICO FEDERAL DE PROCESSAMENTO DE DADOS (SERPRO), O=SERVICO FEDERAL DE PROCESSAMENTO DE DADOS (SERPRO), L=BRASILIA, ST=DISTRITO FEDERAL, C=BR\" (Serial: 162cc214567a6424c9bfc8c1)",
+                            "additionalInfo": "162cc214567a6424c9bfc8c1",
+                            "originPath": "file.certInfos",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" contains a valid digital signature from \"CN=GlobalSign Code Signing Root R45, O=GlobalSign nv-sa, C=BE\" (Serial: 7803184245708a41cf6f01b8eeb4a954)",
+                            "additionalInfo": "7803184245708a41cf6f01b8eeb4a954",
+                            "originPath": "file.certInfos",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" contains a valid digital signature from \"CN=GlobalSign GCC R45 CodeSigning CA 2020, O=GlobalSign nv-sa, C=BE\" (Serial: 77bd0e03a1b708f854ab067210d90447)",
+                            "additionalInfo": "77bd0e03a1b708f854ab067210d90447",
+                            "originPath": "file.certInfos",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "EF001",
+                    "description": "Contains an overlay",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "overlay",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Input file has a \"52734864\" byte overlay at offset \"876032\"",
+                            "additionalInfo": "cde42ac73af4a9a566b44267ad18fddb36078f853e37d06e9df506d62f8ea143",
+                            "originPath": "file.extractedFiles",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "overlay",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "EF002",
+                    "description": "Contains an overlay with an unusually high entropy",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "overlay",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "LIKELY_MALICIOUS",
+                                    "threatLevel": 0.75,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "packed",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "LIKELY_MALICIOUS",
+                                    "threatLevel": 0.75,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Input file has a \"52734864\" byte overlay at offset \"876032\" with an entropy of \"7.99999666214\"",
+                            "additionalInfo": "cde42ac73af4a9a566b44267ad18fddb36078f853e37d06e9df506d62f8ea143",
+                            "originPath": "file.extractedFiles",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "overlay",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "LIKELY_MALICIOUS",
+                                            "threatLevel": 0.75,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "packed",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "LIKELY_MALICIOUS",
+                                            "threatLevel": 0.75,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "SIGG016",
+                    "description": "Executable is a digitally not signed installer",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "signalReadable": "Found an installer which is not digitally signed",
+                            "additionalInfo": "",
+                            "originPath": "signalSummary.allTags",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "dataUUID": "a174480a-b1ec-4c3d-aed2-7f15b206c692"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S007",
+                    "description": "Found a Windows desktop utility string artifact",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"control\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"write\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"convert\"",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "BIN001",
+                    "description": "The executable is using a known installer framework",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1027.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Software Packing"
+                        }
+                    ],
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "installer",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "INFORMATIONAL",
+                                    "threatLevel": 0.25,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The analysis found the signature of a known installer framework (\"Installer: Inno Setup Module(6.1.0)[unicode]\")",
+                            "originPath": "file.dieInfo",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "installer",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "INFORMATIONAL",
+                                            "threatLevel": 0.25,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H030",
+                    "description": "PE imports APIs used to manipulate/query other processes",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1518",
+                            "name": "Software Discovery"
+                        }
+                    ],
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"OpenProcessToken@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H032",
+                    "description": "PE imports APIs used to access or modify the registry",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1012",
+                            "relatedTactic": {
+                                "ID": "TA0007",
+                                "name": "Discovery"
+                            },
+                            "name": "Query Registry"
+                        }
+                    ],
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"RegQueryValueExW@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"RegCloseKey@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"RegOpenKeyExW@advapi32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "PE005",
+                    "description": "PE contains an untrusted digital certificate",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "The artifact \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" contains a \"self-signed\" digital signature from \"CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R3\" (Serial: 4000000000121585308a2)",
+                            "additionalInfo": "4000000000121585308a2",
+                            "originPath": "file.certInfos",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H056",
+                    "description": "PE is created with Inno Setup installation system",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "installer",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "INFORMATIONAL",
+                                    "threatLevel": 0.1,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "PE is a Inno Setup installer",
+                            "originPath": "file.extendedData.verinfo",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "installer",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "INFORMATIONAL",
+                                            "threatLevel": 0.1,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H011",
+                    "description": "PE imports APIs used for anti-debugging purposes",
+                    "averageSignalStrength": 0.25,
+                    "peakSignalStrength": 0.25,
+                    "finalSignalStrength": 0.25,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.25,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"SwitchToThread@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I001",
+                    "description": "OSINT source detected benign resource(s)",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "originPath": "file.inputSampleOSINT.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H035",
+                    "description": "PE imports APIs used to shutdown/lock the system",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1499",
+                            "relatedTactic": {
+                                "ID": "TA0040",
+                                "name": "Impact"
+                            },
+                            "name": "Endpoint Denial of Service"
+                        }
+                    ],
+                    "averageSignalStrength": 0.75,
+                    "peakSignalStrength": 0.75,
+                    "finalSignalStrength": 0.75,
+                    "verdict": {
+                        "verdict": "LIKELY_MALICIOUS",
+                        "threatLevel": 0.75,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.75,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"ExitWindowsEx@user32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H038",
+                    "description": "PE has an uncommon section name",
+                    "averageSignalStrength": 0.5,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.5,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Entrypoint section \".itext\" is unusual",
+                            "originPath": "file.extendedData.sections.sectionName",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Entrypoint section \".didata\" is unusual",
+                            "originPath": "file.extendedData.sections.sectionName",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "H016",
+                    "description": "PE imports APIs used to hide other imports",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryA@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryExW@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"GetProcAddress@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found API reference \"LoadLibraryW@kernel32.dll\"",
+                            "originPath": "file.extendedData.imports.imports",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "S051",
+                    "description": "Found a living off the land (LotL) string artifact",
+                    "allMitreTechniques": [
+                        {
+                            "ID": "T1218.002",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Control Panel"
+                        },
+                        {
+                            "ID": "T1218.011",
+                            "relatedTactic": {
+                                "ID": "TA0005",
+                                "name": "Defense Evasion"
+                            },
+                            "name": "Rundll32"
+                        }
+                    ],
+                    "averageSignalStrength": 0.42,
+                    "peakSignalStrength": 0.5,
+                    "finalSignalStrength": 0.49,
+                    "verdict": {
+                        "verdict": "SUSPICIOUS",
+                        "threatLevel": 0.5,
+                        "confidence": 1
+                    },
+                    "allTags": [
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "control",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "INFORMATIONAL",
+                                    "threatLevel": 0.25,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "lolbin",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "INFORMATIONAL",
+                                    "threatLevel": 0.25,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "setupapi",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        },
+                        {
+                            "source": "SIGNAL",
+                            "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "isRootTag": false,
+                            "tag": {
+                                "name": "shell32",
+                                "synonyms": [],
+                                "descriptions": [],
+                                "verdict": {
+                                    "verdict": "SUSPICIOUS",
+                                    "threatLevel": 0.5,
+                                    "confidence": 1
+                                }
+                            }
+                        }
+                    ],
+                    "signals": [
+                        {
+                            "strength": 0.25,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"control\" (Alternate data streams)",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "control",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "INFORMATIONAL",
+                                            "threatLevel": 0.25,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "lolbin",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "INFORMATIONAL",
+                                            "threatLevel": 0.25,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "mitreTechnique": {
+                                "ID": "T1218.002",
+                                "relatedTactic": {
+                                    "ID": "TA0005",
+                                    "name": "Defense Evasion"
+                                },
+                                "name": "Control Panel"
+                            }
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"setupapi.dll\" (AWL bypass Execute)",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "lolbin",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "setupapi",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "mitreTechnique": {
+                                "ID": "T1218.011",
+                                "relatedTactic": {
+                                    "ID": "TA0005",
+                                    "name": "Defense Evasion"
+                                },
+                                "name": "Rundll32"
+                            }
+                        },
+                        {
+                            "strength": 0.5,
+                            "isStrictlyBasedOnInputData": true,
+                            "signalReadable": "Found string artifact \"shell32.dll\" (Execute)",
+                            "originPath": "file.strings.references",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "tags": [
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "lolbin",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                },
+                                {
+                                    "source": "SIGNAL",
+                                    "sourceIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                                    "isRootTag": false,
+                                    "tag": {
+                                        "name": "shell32",
+                                        "synonyms": [],
+                                        "descriptions": [],
+                                        "verdict": {
+                                            "verdict": "SUSPICIOUS",
+                                            "threatLevel": 0.5,
+                                            "confidence": 1
+                                        }
+                                    }
+                                }
+                            ],
+                            "mitreTechnique": {
+                                "ID": "T1218.011",
+                                "relatedTactic": {
+                                    "ID": "TA0005",
+                                    "name": "Defense Evasion"
+                                },
+                                "name": "Rundll32"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I001",
+                    "description": "OSINT source detected benign resource(s)",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                        }
+                    ]
+                },
+                {
+                    "identifier": "I001",
+                    "description": "OSINT source detected benign resource(s)",
+                    "averageSignalStrength": 0.1,
+                    "peakSignalStrength": 0.1,
+                    "finalSignalStrength": 0.1,
+                    "verdict": {
+                        "verdict": "INFORMATIONAL",
+                        "threatLevel": 0.1,
+                        "confidence": 1
+                    },
+                    "allTags": [],
+                    "signals": [
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"19151c084fcd30aed2f27deed3ec77351f27a94fd9618da56258ea03bbcbc7f3\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "19151c084fcd30aed2f27deed3ec77351f27a94fd9618da56258ea03bbcbc7f3",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "5a4eff64fb4b0abe28b640eec4842f4c8e8f0c8499715d6869416dee6a2fcc4d"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"22296669c2c50d3fdfee9de9f7730d0a5cc498b7cc54cd2aa8ded74d7e69f654\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "22296669c2c50d3fdfee9de9f7730d0a5cc498b7cc54cd2aa8ded74d7e69f654",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "5a4eff64fb4b0abe28b640eec4842f4c8e8f0c8499715d6869416dee6a2fcc4d"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"351e7d3c756242cde2e4a2bef16d636d5e073e0cf3e9cfa2b1da1efccd7806ae\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "351e7d3c756242cde2e4a2bef16d636d5e073e0cf3e9cfa2b1da1efccd7806ae",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "5a4eff64fb4b0abe28b640eec4842f4c8e8f0c8499715d6869416dee6a2fcc4d"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"3c45c82b39b3c90c9c22342a8f6be98073faf1dcd26dbc578b3a6fa9a499cb46\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "3c45c82b39b3c90c9c22342a8f6be98073faf1dcd26dbc578b3a6fa9a499cb46",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "5a4eff64fb4b0abe28b640eec4842f4c8e8f0c8499715d6869416dee6a2fcc4d"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"734b698aafc2cfabfd0750c88498022d650f6ee025250dc8795de56a6e122445\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "734b698aafc2cfabfd0750c88498022d650f6ee025250dc8795de56a6e122445",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "5a4eff64fb4b0abe28b640eec4842f4c8e8f0c8499715d6869416dee6a2fcc4d"
+                        },
+                        {
+                            "strength": 0.1,
+                            "isStrictlyBasedOnInputData": false,
+                            "signalReadable": "OSINT provider \"OPSWAT_REPUTATION\" detected resource \"e7dbe99baa5c1045cdf7004edb037018b2e0f639a5edcf800ec4514d5c8e35b5\" as \"INFORMATIONAL\"",
+                            "additionalInfo": "e7dbe99baa5c1045cdf7004edb037018b2e0f639a5edcf800ec4514d5c8e35b5",
+                            "originPath": "osint.results.verdict",
+                            "originType": "INPUT_FILE",
+                            "originIdentifier": "5a4eff64fb4b0abe28b640eec4842f4c8e8f0c8499715d6869416dee6a2fcc4d"
+                        }
+                    ]
+                }
+            ],
+            "resources": {
+                "8b0bfc9e-8456-41a6-b565-1f5f70f2a232": {
+                    "results": [],
+                    "relatedTaskType": "OSINT_FUZZY_HASH",
+                    "origin": {
+                        "type": "INPUT_FILE",
+                        "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                    },
+                    "resourceReference": {
+                        "type": "OSINT",
+                        "name": "osint",
+                        "ID": "8b0bfc9e-8456-41a6-b565-1f5f70f2a232"
+                    },
+                    "mediaType": {
+                        "string": "application/octet-stream",
+                        "slash": 11,
+                        "semicolon": 24,
+                        "parameters": {}
+                    },
+                    "signalGroupsByID": {},
+                    "signalGroups": [],
+                    "allTags": [],
+                    "originVerdicts": [],
+                    "verdict": {
+                        "verdict": "UNKNOWN",
+                        "threatLevel": 0,
+                        "confidence": 1
+                    },
+                    "notifications": []
+                }
+            },
+            "iocs": {
+                "sha1": [
+                    {
+                        "data": "a78f44fbaa8fe1af42d182bdf6bba10298e8f9d0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f9e4dd288cf9c760941cadb475675c52e660a4e3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "19969a1f68d497f0114538352da478b41c3d2060",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "95641a365d88f070bcbd921d99bc1c034e92340e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "2c365c0341faf71f810a39c69859a7eb5bc0de8d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "c8abb69fb38434daf6811309cc88e9d0df65e2cd",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "593953973c74066bcd09b22402948425dab9b12f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "054aa93663138220373081b25672499d38cb2eaf",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ed16991f4f735f8258ff195bed5f1641d1405cc9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "64a194ea368bb16ffac3e7a4ca84b3c00bf15920",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "139a84f87110fb5cb16a386adade21f30cae98b0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b70589a036a33681a1dfb9cf0ae1c044093105bc",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "30704560832bafa440df1fd20693653c2a30f815",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "2c39cf9c2c1cfab48077cda2d4d6312fdb53c54b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "81703bf084f800ff3fb6a59946afe4d61e19da0a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "881ed848fcd0fd28cc0374dcf424ac1b511449d7",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8b440004b69538573b6cb4d11524bb9a05aa08d9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "9d8217a9fe24717ad0458df8cda78581baf9203b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "4d558ad1d7d9df7bb9745a3ec624ceb6853ae027",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "210176c87e076551111487ca538c2c4cc0dc4001",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b164bf0882b60c0d7d4643495a2c1db5a20a1343",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "dc6002a243c7567105aef957d8b01142df42b3d2",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "191abfb842d1dc6148f60cd86449cfa9b4a43047",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha256": [
+                    {
+                        "data": "cde42ac73af4a9a566b44267ad18fddb36078f853e37d06e9df506d62f8ea143",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "05febfad978958780fbcd54073fa28228f5375cf4e2d5df5310f3cd8e47e491f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "51209c8034cd5c2127a7b877a3280699d6bad965bcc102e830420c836f535c97",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "30e3536a32c2509357a5472a0eff9335cb5b5607fde8d7ca82bd7a03f9a60ebc",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "30058e7862f12edbefb181bc36b6443828b9fba9d2f5bb6bfd4a3927d579e46b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "63bc73ffa28e0af5077c1bb882c913cdcd2765a34288451c15b8fa832477cc43",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "bb650ee3d30d21f22fc7853936b06be7cbfd05b4d88ed105d3e53774dae7f21f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e091f8e6206b0fba3798d99b465e8c33082ebed634fa71886e1a9f002e99730f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "22296669c2c50d3fdfee9de9f7730d0a5cc498b7cc54cd2aa8ded74d7e69f654",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "19151c084fcd30aed2f27deed3ec77351f27a94fd9618da56258ea03bbcbc7f3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b33f156b0a8ce96c7182dfb6afa9f6a7020433a6e16ca21f6092ba03695bdd12",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "99b7194bf59ac43cbbdc441ab7ca14ab0330449accd33730281da09bb96bcbe3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "2e6d8102640132ccabd2fa3c3a61c77c2b41a80d7f60013cf7149819c2b5c9d2",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "75bb01fe4bafdef22d879aaea5b85d1165a30ec0e558536e1b4c6002c4730d5d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0852b5fce0c5b7ff53fe4c4163983daf8a2057d5481911c24253f330bfd65d9a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "b3804a4ce8e8f4b7b07a26f688b4a122e22857398c9979cc869a215c50d2b70e",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "68d71a16528396835848137bd6c36b3b55c116f78a448b900721d87bd04771b8",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "3bac7ddac05247d073f294071903715ef0aec49c8a24f2bbae4927ec51260d27",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "351e7d3c756242cde2e4a2bef16d636d5e073e0cf3e9cfa2b1da1efccd7806ae",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "734b698aafc2cfabfd0750c88498022d650f6ee025250dc8795de56a6e122445",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "4be11ded6c924c3181c0b2a17cbf6f017fbf2b074adadaae213a330711e22cd1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "3c45c82b39b3c90c9c22342a8f6be98073faf1dcd26dbc578b3a6fa9a499cb46",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e7dbe99baa5c1045cdf7004edb037018b2e0f639a5edcf800ec4514d5c8e35b5",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "ip": [
+                    {
+                        "data": "75.119.223.113",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "domain": [
+                    {
+                        "data": "schemas.microsoft.com",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "jrsoftware.org",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "w3.org",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1c67a524eade7a5a0cfcce57bc321816f979ad069438b9a8f502a3ee5124ae67"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "sha512": [
+                    {
+                        "data": "446ec1fb6532cfbebc0ccf4b5388fd0e963af33f14e74d1749b21765aefed34e0f7786d8fd9041912253491b34070f4dd107bde05d9820bab8341267447392e9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "9f14cffb99a4e46ac633a9df459e6359a8fe373946896de43ed78a38899d8cf3ebea6d6723c6b3d5d9a856232af794dbbfa347496b80bd8118e0120e0a1a726d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "94366a2d90e224dd32bf106bfb97e19addb3f83ebb2580ca3996a7ce5e2813a45840e910162ac92dc5de988d90f60d9e882c414e8b2f908f6134bddc18b514d7",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "67c4c2ef03c7fa88babe0032bdb2e2887a676bf5116e3116079b01bbd7d5a4f511aaaf1b393f872ec2746ff06d0429201c4a26e71d485be497e67bde88d6ec5c",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "bc7c322301145c58aa2979da469b93e1bfa396f586dd4feaecd1a90aef459c7c075cefeab92f9ea2ce16a246afcf604e099d11a03d3dc9d13d3c0afbc4bfd6d0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0f937059fff95bfa6548448f43f1e5d51b6732ac625c135fe84fe40780f5473c03e6cb0b5bb3383ebe0edb0f950e7ffd08fee2f2a707da9748c23d0c91787b16",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "639a097103aafacf7a28b55c4912859368c20d6eb1ebdff34b60a5d1b194c5077c61ed131a5f0a158c1bc8de3bb4d11fed67b907ad5fefccd4ffd6c967101808",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ff31a6fd2c55f2419eb296fcf2d3bd2e3f40c3438f521a9c5c5077e0753462d690dc95b054a4adfa6784681416ee20d3ff6bea2b6b8076d74f245bdc15658e06",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "9be908d7e1335550c777d4c60c6d315e20b761c102f824354105d77157bdea48daf5750728f0e439c6ee838edc0bba107d1144f57c60735a08f9afc22a9a5d7d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7e6e96224e3b705164b39a08a1ec245cf97cc5255b790ceca7fef57f2f112e55975f3d070db8ead20144ce46915a9169e28b61a638e602df9dc1c10579134d3f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "5eecdf060ff4f7cbf92b43f34e0be04f3372ec0231d754869391f8d5ed0c03ba551abb986c7df43312def628568d2a28fac4a46c1e43b09566626315f31f0962",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "61c14fca37a17b5f97db4c4d11c2929f9d1c46e00e6e013c5a1fbf0edbad486bb33a4e34d2af698209dc41bcdda8821fd422cbfdb41228d7a91ef3f9039035d3",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "ec83ebf28016d3cbd6fd2e5c9a35d582adbfeb81cade47cfa258da709fa90c6fecf2f1ce894132a7c25668b4ff278f888757961ab5de73d442aa5982f5caf85b",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "da8a269c92d01acc963595800f63421b0ac19a02fe8ca3dd9d3db668876e080cb5fb9f088bed9879789d940402a707f0339c9a989f6d71f4547b48031a00fcf4",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "88cb5543993103ba68d8a4aacd797e175920129bc0c129a8af97ca3e886927945087a1bb227d4735222ae6b8437dfa36638b2555c9682d29723f6b53a9ae1ce6",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "75577743c0d0ff226ed9bbcff6891d8c8c8b5013262aae11d4759738ab214708cc362c84d3d37d4eb3bf98096d334ee0fe82225eae12c19c9cf52e87c36d4727",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "128318b6862e6834925a3c39cde22c17035c23078b2d38b9b27c54d1dd60ffb40296ff9688014055ca547360ed103986681f13797508ace536a25fc67d873887",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "cd22fa5cba2591690f61cd96da4036d2078a9e8e33249387745c1c9e08e0c1887296163367cdfcb88346a4e9931e261c23037c6a60aa455af857b48a3bc78bb9",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "36baf90c3936c013be089c7582f2a185d26411b5ed69a930c9ab5d5c3471bb1ef65c75087b99644ba5ac611176bfc312eb6199ffe5731d81d82f86d961c62af1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0ba8bcb4f1d9a2fda66bf2094235da0c6e24752ef2a2edbaf75bcc014c9dc95fc675e3f46318465be625f9299083bb27103bb8cfe29ed8ad7b6ccca6adf61055",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e9e6729a898a023d34ba33073e29d4e35126f5d14e28ccca79a8132a01018a7bd54cfd79967d497d9a4fa4f26033b24c4541897685912c80eb644604d4f51179",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "328529a3e6fff4185190f97dc5aea5ad08dc7c031952d67b1ebb1aebad82c37e94d4b0ff5a62c6e2baf5b2ea5454340bf0284ca5656709b66fd717d6e9e3116a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "09f7126bcea32f91f39819de654cdb4acddbb40880e9c37c54c5cca0a47863f0fad97f90ef2597c28731aec0f05227d585833b347300fd8c8caa8a6a016cdce6",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "uuid": [
+                    {
+                        "data": "1f676c76-80e1-4239-95bb-83d0f6d0da78",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e2011457-1546-43c5-a5fe-008deee3d3f0",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "35138b9a-5d96-4fbd-8e2d-a2440225f93a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "url": [
+                    {
+                        "data": "http://www.w3.org/1999/xhtml",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1c67a524eade7a5a0cfcce57bc321816f979ad069438b9a8f502a3ee5124ae67"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd",
+                        "origins": [
+                            {
+                                "type": "EXTRACTED_FILE",
+                                "identifier": "1c67a524eade7a5a0cfcce57bc321816f979ad069438b9a8f502a3ee5124ae67"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "https://jrsoftware.org/ishelp/index.php?topic=setupcmdline",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "http://schemas.microsoft.com/SMI/2005/WindowsSettings",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "registry_path": [
+                    {
+                        "data": "Software\\Borland\\Locales",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "Software\\Borland\\Delphi\\Locales",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "Software\\Embarcadero\\Locales",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "Software\\CodeGear\\Locales",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ],
+                "md5": [
+                    {
+                        "data": "22bd761820c0d64ac6866f56e58e8069",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "186e8b284df616726dd2e02f3b908831",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d0969cc9a96275d54a109de740708a5a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d1efb0d972603f09c3a2a866a8b36d48",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e07ab8c9030f776ce0f6d9040d41c616",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e8e4995b464abd85d77008d3750ca7af",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "98da6167be9a4eb3be8bab5877938ff2",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "09208f24be8c3f3b08c323e9836db5e6",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "def52a5b1e8bba58fe020b2c959f5c4f",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "a40263c75fde7440b1086b7da9c51fc2",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "d2467f70311fc072d9202909bdfa9fcb",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "aeb11111a0334d20d978e15c3eb3ebab",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "110abe16232608d8671eaca8ee324f45",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "e7cbab9e4b301ee7e5ec1e09c0b084ba",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "c7d3a1e14afcb8402a656a27156f7a00",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "697028c6576655ef520aa0d99011c6d1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "1c9252919f0a0d2072f3fe0565f0b443",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "de899aac74105149ca395b0548549fc1",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "7acc30378a3661ecca806f547c8e4cfc",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "f8cd0efcff1461af9c4d6a7d4fab4c0d",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "21cba6c9d478ce13ad53587cdd7f21f8",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "0d708a089fabb88286009f3f5c509a9a",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    },
+                    {
+                        "data": "4ac29bb5f7361e85771807112cd4ec93",
+                        "origins": [
+                            {
+                                "type": "INPUT_FILE",
+                                "identifier": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08"
+                            }
+                        ],
+                        "isInteresting": false
+                    }
+                ]
+            },
+            "file": {
+                "name": "assinador-serpro-4-2-0.exe",
+                "hash": "bd16e02e72d3cbc4326e36f2ca27cad2bc69434a3733879f07c95d2b2cf66f08",
+                "type": "pe"
+            },
+            "filesDownloadFinished": true,
+            "additionalStepsRunning": [],
+            "additionalStepsDone": true,
+            "created_date": "10/19/2023, 16:25:16",
+            "defaultOptionsUsed": true,
+            "scanOptions": {
+                "rapid_mode": false,
+                "osint": true,
+                "extended_osint": true,
+                "extracted_files_osint": true,
+                "visualization": true,
+                "files_download": true,
+                "resolve_domains": true,
+                "input_file_yara": true,
+                "extracted_files_yara": true,
+                "whois": true,
+                "ips_meta": true,
+                "images_ocr": true
+            },
+            "estimatedTime": "9",
+            "estimated_progress": 1.0
+        }
+    }
+}

--- a/tests/test_opswat.py
+++ b/tests/test_opswat.py
@@ -1,0 +1,108 @@
+import io
+from unittest import TestCase
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+import responses
+import sandboxapi.opswat
+from . import read_resource
+
+
+URL = "http://filescanio.mock"
+
+
+class TestOPSWAT(TestCase):
+    def setUp(self):
+        self.sandbox = sandboxapi.opswat.OPSWATSandboxAPI("key", URL, True)
+
+    # analyze
+    @responses.activate
+    def test_analyze(self):
+        sent_file_response = {"flow_id": "1234"}
+
+        responses.add(responses.POST, f"{URL}/api/scan/file", json=sent_file_response)
+        self.assertEqual(
+            self.sandbox.analyze(io.BytesIO("test".encode("ascii")), "filename"), "1234"
+        )
+
+    # check
+    @responses.activate
+    def test_check(self):
+        flow_id = 1
+        finished = [
+            ("opswat_submissions_result_malicious", True),
+            ("opswat_submissions_result_not_finished", False),
+        ]
+        for report in finished:
+            responses.add(
+                responses.GET,
+                f"{URL}/api/scan/{flow_id}/report",
+                json=read_resource(report[0]),
+            )
+            self.assertEqual(self.sandbox.check("1"), report[1])
+
+    # is available
+    @responses.activate
+    def test_is_available(self):
+        response = {
+            "accountId": "1234",
+        }
+        responses.add(responses.GET, f"{URL}/api/users/me", json=response)
+        self.assertTrue(self.sandbox.is_available())
+
+    @responses.activate
+    def test_not_available(self):
+        response = {
+            "accountId": "1234",
+        }
+        responses.add(responses.GET, f"{URL}/api/users/me", json=response, status=404)
+        self.assertFalse(self.sandbox.is_available())
+
+    # report
+    @responses.activate
+    def test_report(self):
+        id = 1
+        url = f"{URL}/api/scan/{id}/report?filter=general&filter=finalVerdict&filter=allTags&filter=overallState&filter=taskReference&filter=subtaskReferences&filter=allSignalGroups"
+
+        responses.add(
+            responses.GET,
+            url,
+            json=read_resource("opswat_submissions_result_malicious"),
+        )
+
+        response = self.sandbox.report(id)
+        self.assertEqual(
+            response,
+            read_resource("opswat_submissions_result_malicious"),
+        )
+
+        self.assertEqual(
+            response["reports"]["f7977db1-6a99-46c3-8567-de1c88c93aa4"]["finalVerdict"][
+                "verdict"
+            ],
+            "MALICIOUS",
+        )
+
+    # score
+    @responses.activate
+    def test_score(self):
+        id = 1
+        files_and_score = [
+            ("opswat_submissions_result_malicious", 100),
+            ("opswat_submissions_result_suspicious", 50),
+            ("opswat_submissions_result_benign", 0),
+            ("opswat_submissions_result_likely_malicious", 75),
+        ]
+
+        for file_and_score in files_and_score:
+            responses.add(
+                responses.GET,
+                f"{URL}/api/scan/{id}/report?filter=general&filter=finalVerdict&filter=allTags&filter=overallState&filter=taskReference&filter=subtaskReferences&filter=allSignalGroups",
+                json=read_resource(file_and_score[0]),
+            )
+            self.assertEqual(
+                self.sandbox.score(self.sandbox.report(id)), file_and_score[1]
+            )

--- a/tests/test_opswat.py
+++ b/tests/test_opswat.py
@@ -65,7 +65,7 @@ class TestOPSWAT(TestCase):
     @responses.activate
     def test_report(self):
         id = 1
-        url = f"{URL}/api/scan/{id}/report?filter=general&filter=finalVerdict&filter=allTags&filter=overallState&filter=taskReference&filter=subtaskReferences&filter=allSignalGroups"
+        url = f"{URL}/api/scan/{id}/report?filter=general&filter=finalVerdict&filter=allTags&filter=overallState&filter=taskReference&filter=subtaskReferences&filter=allSignalGroups&filter=iocs"
 
         responses.add(
             responses.GET,
@@ -100,7 +100,7 @@ class TestOPSWAT(TestCase):
         for file_and_score in files_and_score:
             responses.add(
                 responses.GET,
-                f"{URL}/api/scan/{id}/report?filter=general&filter=finalVerdict&filter=allTags&filter=overallState&filter=taskReference&filter=subtaskReferences&filter=allSignalGroups",
+                f"{URL}/api/scan/{id}/report?filter=general&filter=finalVerdict&filter=allTags&filter=overallState&filter=taskReference&filter=subtaskReferences&filter=allSignalGroups&filter=iocs",
                 json=read_resource(file_and_score[0]),
             )
             self.assertEqual(


### PR DESCRIPTION
### OPSWAT Filescan Sandbox

- Removed old opswat.py file and created a new one
- OPSWAT integration now use the OPSWAT Filescan Sandbox 
- Added test files and test cases as well
- Extended the README.rst file

For usage it is necessary to have an OPSWAT Filescan Sandbox API-key, 
Default host is [OPSWAT Filescan Community](https://www.filescan.io) 

Example availability check under sandboxapi dir (call main directly):
```
python opswat.py "https://www.filescan.io" "your-api-key" available   
```

Usage within code:
```
from sandboxapi import opswat

# connect to the sandbox
sandbox = opswat.OPSWATSandboxAPI("your-api-key")

print("Does sandbox available?")
print(sandbox.is_available())
```
 